### PR TITLE
reduce the test verbosity

### DIFF
--- a/test.py
+++ b/test.py
@@ -238,7 +238,6 @@ class StorageTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stderr)
-    logging.getLogger().setLevel(logging.DEBUG)
+    logging.basicConfig()
     logging.getLogger("urllib3").setLevel(logging.INFO)
     unittest.main()


### PR DESCRIPTION
Cleans up a bunch of test log messages from sub projects such as:

```
DEBUG:web3.RequestManager:Making request. Method: eth_call
DEBUG:web3.providers.HTTPProvider:Making request HTTP. URI: http://ganache:8545, Method: eth_call
DEBUG:web3.providers.HTTPProvider:Getting response HTTP. URI: http://ganache:8545, Method: eth_call, Response: {'id': 181, 'jsonrpc': '2.0', 'result': '0x0000000000000000000000000000000000000000000000000000000000000001'}
DEBUG:web3.RequestManager:Making request. Method: eth_getBlockByNumber
```