### PR TITLE
Add support for bulk payout in the API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -39,6 +39,7 @@ def _unlock_account_or_raise(account: str) -> None:
 def _validate_account_or_raise(account: str) -> str:
     return account
 
+
 def _bulk_payout_sol(contract: WContract,
                      addresses: list,
                      amounts: list,
@@ -59,6 +60,7 @@ def _bulk_payout_sol(contract: WContract,
                                         })
     tx_hash = sign_and_send_transaction(tx_dict, GAS_PAYER_PRIV)
     wait_on_transaction(tx_hash)
+
 
 def _partial_payout_sol(contract: WContract,
                         amount: int,
@@ -319,14 +321,14 @@ class Contract(Manifest):
         LOG.info("We payout: {}".format(hmt_amount))
         return partial_payout(self.job_contract, hmt_amount, to_address, url,
                               hash_)
-    
+
     def bulk_payout(self, addresses: list, amounts: list, results: dict,
                     public_key: bytes, private_key: bytes):
         (hash_, url) = upload(results, public_key)
         hmt_amounts = [_convert_to_hmt_cents(amount) for amount in amounts]
         LOG.info("HMT amounts for bulk payout: {}".format(hmt_amounts))
         return _bulk_payout_sol(self.job_contract, addresses, hmt_amounts, url,
-                              hash_)
+                                hash_)
 
     def complete(self) -> bool:
         try:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -49,7 +49,7 @@ def _bulk_payout_sol(contract: WContract,
     W3 = get_w3()
     nonce = W3.eth.getTransactionCount(GAS_PAYER)
 
-    tx_dict = contract.functions.payOut(addresses, amounts, uri,
+    tx_dict = contract.functions.bulkPayOut(addresses, amounts, uri,
                                         hash_).buildTransaction({
                                             'from':
                                             GAS_PAYER,

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -319,6 +319,14 @@ class Contract(Manifest):
         LOG.info("We payout: {}".format(hmt_amount))
         return partial_payout(self.job_contract, hmt_amount, to_address, url,
                               hash_)
+    
+    def bulk_payout(self, addresses: list, amounts: list, results: dict,
+                    public_key: bytes, private_key: bytes):
+        (hash_, url) = upload(results, public_key)
+        hmt_amounts = [_convert_to_hmt_cents(amount) for amount in amounts]
+        LOG.info("HMT amounts for bulk payout: {}".format(hmt_amounts))
+        return _bulk_payout_sol(self.job_contract, addresses, hmt_amounts, url,
+                              hash_)
 
     def complete(self) -> bool:
         try:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -50,14 +50,14 @@ def _bulk_payout_sol(contract: WContract,
     nonce = W3.eth.getTransactionCount(GAS_PAYER)
 
     tx_dict = contract.functions.bulkPayOut(addresses, amounts, uri,
-                                        hash_).buildTransaction({
-                                            'from':
-                                            GAS_PAYER,
-                                            'gas':
-                                            gas,
-                                            'nonce':
-                                            nonce
-                                        })
+                                            hash_).buildTransaction({
+                                                'from':
+                                                GAS_PAYER,
+                                                'gas':
+                                                gas,
+                                                'nonce':
+                                                nonce
+                                            })
     tx_hash = sign_and_send_transaction(tx_dict, GAS_PAYER_PRIV)
     wait_on_transaction(tx_hash)
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -326,8 +326,11 @@ class Contract(Manifest):
                     public_key: bytes, private_key: bytes):
         (hash_, url) = upload(results, public_key)
         hmt_amounts = [_convert_to_hmt_cents(amount) for amount in amounts]
+        hmt_rep_oracle_fee = _convert_to_hmt_cents(self.oracle_stake)
+        hmt_rec_oracle_fee = _convert_to_hmt_cents(self.oracle_stake)
         LOG.info("HMT amounts for bulk payout: {}".format(hmt_amounts))
-        return _bulk_payout_sol(self.job_contract, addresses, hmt_amounts, url,
+        return _bulk_payout_sol(self.job_contract, addresses, hmt_amounts,
+                                hmt_rep_oracle_fee, hmt_rec_oracle_fee, url,
                                 hash_)
 
     def complete(self) -> bool:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -39,6 +39,26 @@ def _unlock_account_or_raise(account: str) -> None:
 def _validate_account_or_raise(account: str) -> str:
     return account
 
+def _bulk_payout_sol(contract: WContract,
+                     addresses: list,
+                     amounts: list,
+                     uri: str,
+                     hash_: str,
+                     gas=DEFAULT_GAS):
+    W3 = get_w3()
+    nonce = W3.eth.getTransactionCount(GAS_PAYER)
+
+    tx_dict = contract.functions.payOut(addresses, amounts, uri,
+                                        hash_).buildTransaction({
+                                            'from':
+                                            GAS_PAYER,
+                                            'gas':
+                                            gas,
+                                            'nonce':
+                                            nonce
+                                        })
+    tx_hash = sign_and_send_transaction(tx_dict, GAS_PAYER_PRIV)
+    wait_on_transaction(tx_hash)
 
 def _partial_payout_sol(contract: WContract,
                         amount: int,

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -49,8 +49,8 @@ def _bulk_payout_sol(contract: WContract,
     W3 = get_w3()
     nonce = W3.eth.getTransactionCount(GAS_PAYER)
 
-    tx_dict = contract.functions.bulkPayOut(addresses, amounts, uri,
-                                            hash_).buildTransaction({
+    tx_dict = contract.functions.bulkPayOut(addresses, amounts, uri, hash_,
+                                            1).buildTransaction({
                                                 'from':
                                                 GAS_PAYER,
                                                 'gas':
@@ -326,11 +326,8 @@ class Contract(Manifest):
                     public_key: bytes, private_key: bytes):
         (hash_, url) = upload(results, public_key)
         hmt_amounts = [_convert_to_hmt_cents(amount) for amount in amounts]
-        hmt_rep_oracle_fee = _convert_to_hmt_cents(self.oracle_stake)
-        hmt_rec_oracle_fee = _convert_to_hmt_cents(self.oracle_stake)
         LOG.info("HMT amounts for bulk payout: {}".format(hmt_amounts))
-        return _bulk_payout_sol(self.job_contract, addresses, hmt_amounts,
-                                hmt_rep_oracle_fee, hmt_rec_oracle_fee, url,
+        return _bulk_payout_sol(self.job_contract, addresses, hmt_amounts, url,
                                 hash_)
 
     def complete(self) -> bool:

--- a/api/eth_bridge.py
+++ b/api/eth_bridge.py
@@ -73,7 +73,7 @@ def get_contract_interface(contract_entrypoint):
 
 def get_eip20():
     global EIP20ADDR, CONTRACT
-    contract_interface = get_contract_interface('<stdin>:EIP20Interface')
+    contract_interface = get_contract_interface('<stdin>:HMTokenInterface')
     contract = W3.eth.contract(
         address=EIP20ADDR, abi=contract_interface['abi'])
     return contract

--- a/hmt.sol
+++ b/hmt.sol
@@ -510,8 +510,8 @@ contract Escrow {
         require(status != EscrowStatuses.Paid, "Escrow in Paid status state");
         uint256 bulkAmount = getBulkValue(_amounts);
         require(bulkAmount <= balance);
-        require(_reputationOracleFee == getOracleFee(balance, reputationOracleStake));
-        require(_recordingOracleFee == getOracleFee(balance, recordingOracleStake));
+        require(_reputationOracleFee == getOracleFee(bulkAmount, reputationOracleStake));
+        require(_recordingOracleFee == getOracleFee(bulkAmount, recordingOracleStake));
 
         resultsManifestUrl = _url;
         resultsManifestHash = _hash;

--- a/hmt.sol
+++ b/hmt.sol
@@ -329,7 +329,7 @@ contract Escrow {
         expiration = _expiration.add(block.timestamp); // solhint-disable-line not-rely-on-time
     }
 
-    function getBulkValue(_values) public view returns(uint256) {
+    function getBulkValue(uint256[] _values) public view returns(uint256) {
         uint256 bulkAmount = 0;
         for (uint j = 0; j < _values.length; ++j) {
             require(_values[j] > 0);
@@ -462,7 +462,8 @@ contract Escrow {
         address[] _recipients, 
         uint256[] _amounts, 
         string _url, 
-        string _hash
+        string _hash,
+        uint256 _txId
     ) public returns (bool) 
     {
         require(expiration > block.timestamp, "Contract expired");  // solhint-disable-line not-rely-on-time
@@ -471,13 +472,13 @@ contract Escrow {
         require(balance > 0, "EIP20 contract out of funds");
         require(status != EscrowStatuses.Launched, "Escrow in Launched status state");
         require(status != EscrowStatuses.Paid, "Escrow in Paid status state");
-        uint256 bulkAmount = getBulkValue();
+        uint256 bulkAmount = getBulkValue(_amounts);
         require(bulkAmount <= balance);
 
         resultsManifestUrl = _url;
         resultsManifestHash = _hash;
 
-        bool success = hmt.transferBulk(_recipients, _amounts, _hash);
+        bool success = hmt.transferBulk(_recipients, _amounts, _txId) == _recipients.length;
         balance = getBalance();
         if (balance > 0) {
             success = hmt.transfer(canceler, balance);

--- a/hmt.sol
+++ b/hmt.sol
@@ -329,6 +329,15 @@ contract Escrow {
         expiration = _expiration.add(block.timestamp); // solhint-disable-line not-rely-on-time
     }
 
+    function getBulkValue(_values) public view returns(uint256) {
+        uint256 bulkAmount = 0;
+        for (uint j = 0; j < _values.length; ++j) {
+            require(_values[j] > 0);
+            bulkAmount = bulkAmount.add(_values[j]);
+        }
+        return bulkAmount;
+    }
+
     function getStatus() public view returns (EscrowStatuses) {
         return status;
     }
@@ -462,6 +471,9 @@ contract Escrow {
         require(balance > 0, "EIP20 contract out of funds");
         require(status != EscrowStatuses.Launched, "Escrow in Launched status state");
         require(status != EscrowStatuses.Paid, "Escrow in Paid status state");
+        uint256 bulkAmount = getBulkValue();
+        require(bulkAmount <= balance);
+
         resultsManifestUrl = _url;
         resultsManifestHash = _hash;
 

--- a/hmt.sol
+++ b/hmt.sol
@@ -507,6 +507,24 @@ contract Escrow {
 
         resultsManifestUrl = _url;
         resultsManifestHash = _hash;
+        uint256 reputationOracleFee = 0;
+        uint256 recordingOracleFee = 0;
+
+        for (uint j = 0; j < _values.length; ++j) {
+            require(_values[j] > 0);
+            uint256 reputationOracleCut = reputationOracleStake.mul(_values[j]).div(100);
+            uint256 recordingOracleCut = recordingOracleStake.mul(_values[j]).div(100);
+            require(reputationOracleCut < _values[j] && reputationOracleCut >= 0);
+            require(recordingOracleCut < _values[j] && reputationOracleCut >= 0);
+            _values[j] = _values[j].sub(reputationOracleCut).sub(recordingOracleCut);
+            reputationOracleFee.add(reputationOracleCut);
+            recordingOracleFee.add(recordingOracleCut);
+        }
+
+        _recipients.push(reputationOracle);
+        _amounts.push(reputationOracleFee);
+        _recipients.push(recordingOracle);
+        _amounts.push(recordingOracleFee);
 
         bool success = hmt.transferBulk(_recipients, _amounts, _txId) == _recipients.length;
         balance = getBalance();

--- a/hmt.sol
+++ b/hmt.sol
@@ -329,7 +329,7 @@ contract Escrow {
         expiration = _expiration.add(block.timestamp); // solhint-disable-line not-rely-on-time
     }
 
-    function getBulkValue(uint256[] _values) public view returns(uint256) {
+    function getBulkValue(uint256[] _values) public pure returns(uint256) {
         uint256 bulkAmount = 0;
         for (uint j = 0; j < _values.length; ++j) {
             require(_values[j] > 0);
@@ -338,7 +338,7 @@ contract Escrow {
         return bulkAmount;
     }
 
-    function getOracleFee(uint256 _amount, uint256 _oracleStake) public view returns(uint256) {
+    function getOracleFee(uint256 _amount, uint256 _oracleStake) public pure returns(uint256) {
         return _oracleStake.mul(_amount).div(100);
     }
 

--- a/hmt.sol
+++ b/hmt.sol
@@ -510,13 +510,13 @@ contract Escrow {
         uint256 reputationOracleFee = 0;
         uint256 recordingOracleFee = 0;
 
-        for (uint j = 0; j < _values.length; ++j) {
-            require(_values[j] > 0);
-            uint256 reputationOracleCut = reputationOracleStake.mul(_values[j]).div(100);
-            uint256 recordingOracleCut = recordingOracleStake.mul(_values[j]).div(100);
-            require(reputationOracleCut < _values[j] && reputationOracleCut >= 0);
-            require(recordingOracleCut < _values[j] && reputationOracleCut >= 0);
-            _values[j] = _values[j].sub(reputationOracleCut).sub(recordingOracleCut);
+        for (uint j = 0; j < _amounts.length; ++j) {
+            require(_amounts[j] > 0);
+            uint256 reputationOracleCut = reputationOracleStake.mul(_amounts[j]).div(100);
+            uint256 recordingOracleCut = recordingOracleStake.mul(_amounts[j]).div(100);
+            require(reputationOracleCut < _amounts[j] && reputationOracleCut >= 0);
+            require(recordingOracleCut < _amounts[j] && reputationOracleCut >= 0);
+            _amounts[j] = _amounts[j].sub(reputationOracleCut).sub(recordingOracleCut);
             reputationOracleFee.add(reputationOracleCut);
             recordingOracleFee.add(recordingOracleCut);
         }

--- a/hmt.sol
+++ b/hmt.sol
@@ -66,11 +66,21 @@ library SafeMath {
 }
 
 
-contract EIP20Interface {
+contract HMTokenInterface {
+    /* This is a slight change to the ERC20 base standard.
+    function totalSupply() constant returns (uint256 supply);
+    is replaced with:
+    uint256 public totalSupply;
+    This automatically creates a getter function for the totalSupply.
+    This is moved to the base contract since public getter functions are not
+    currently recognised as an implementation of the matching abstract
+    function by the compiler.
+    */
     /// total amount of tokens
     uint256 public totalSupply;
 
-    function fund() public payable returns(bool success) { }  // solhint-disable-line no-empty-blocks
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
 
     /// @param _owner The address from which the balance will be retrieved
     /// @return The balance
@@ -99,12 +109,152 @@ contract EIP20Interface {
     /// @param _spender The address of the account able to transfer the tokens
     /// @return Amount of remaining tokens allowed to spent
     function allowance(address _owner, address _spender) public view returns (uint256 remaining);
+}
 
-    /* solhint-disable no-simple-event-func-name */
-    event Transfer(address indexed _from, address indexed _to, uint256 _value);
-    /* solhint-enable no-simple-event-func-name */
+contract HMToken is HMTokenInterface {
+    using SafeMath for uint256;
+    uint256 private constant MAX_UINT256 = 2**256 - 1;
+    uint256 private constant BULK_MAX_VALUE = 1000000000 * (10 ** 18);
+    uint32  private constant BULK_MAX_COUNT = 100;
 
-    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+    event BulkTransfer(uint256 indexed _txId, uint256 _bulkCount);
+    event BulkApproval(uint256 indexed _txId, uint256 _bulkCount);
+
+    mapping (address => uint256) private balances;
+    mapping (address => mapping (address => uint256)) private allowed;
+
+    string public name;
+    uint8 public decimals;
+    string public symbol;
+
+    constructor(uint256 _totalSupply, string _name, uint8 _decimals, string _symbol) public {
+        totalSupply = _totalSupply * (10 ** uint256(_decimals));
+        name = _name;
+        decimals = _decimals;
+        symbol = _symbol;
+        balances[msg.sender] = totalSupply;
+    }
+
+    function transfer(address _to, uint256 _value) public returns (bool success) {
+        success = transferQuiet(_to, _value);
+        require(success, "Transfer didn't succeed");
+        return success;
+    }
+
+    function transferFrom(address _spender, address _to, uint256 _value) public returns (bool success) {
+        uint256 _allowance = allowed[_spender][msg.sender];
+        require(balances[_spender] >= _value && _allowance >= _value, "Spender balance or allowance too low");
+        require(_to != address(0), "Can't send tokens to uninitialized address");
+
+        balances[_spender] = balances[_spender].sub(_value);
+        balances[_to] = balances[_to].add(_value);
+
+        if (_allowance < MAX_UINT256) { // Special case to approve unlimited transfers
+            allowed[_spender][msg.sender] = allowed[_spender][msg.sender].sub(_value);
+        }
+
+        emit Transfer(_spender, _to, _value);
+        return true;
+    }
+
+    function balanceOf(address _owner) public view returns (uint256 balance) {
+        return balances[_owner];
+    }
+
+    function approve(address _spender, uint256 _value) public returns (bool success) {
+        require(_spender != address(0), "Token spender is an uninitialized address");
+        
+        allowed[msg.sender][_spender] = _value;
+        emit Approval(msg.sender, _spender, _value); //solhint-disable-line indent, no-unused-vars
+        return true;
+    }
+
+    function increaseApproval(address _spender, uint _delta) public returns (bool success) {
+        require(_spender != address(0), "Token spender is an uninitialized address");
+        
+        uint _oldValue = allowed[msg.sender][_spender];
+        if (_oldValue.add(_delta) < _oldValue || _oldValue.add(_delta) >= MAX_UINT256) { // Truncate upon overflow.
+            allowed[msg.sender][_spender] = MAX_UINT256.sub(1);
+        } else {
+            allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_delta);
+        }
+        emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+        return true;
+    }
+
+    function decreaseApproval(address _spender, uint _delta) public returns (bool success) {
+        require(_spender != address(0), "Token spender is an uninitialized address");
+        
+        uint _oldValue = allowed[msg.sender][_spender];
+        if (_delta > _oldValue) { // Truncate upon overflow.
+            allowed[msg.sender][_spender] = 0;
+        } else {
+            allowed[msg.sender][_spender] = allowed[msg.sender][_spender].sub(_delta);
+        }
+        emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+        return true;
+    }
+
+    function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
+        return allowed[_owner][_spender];
+    }
+
+    function transferBulk(address[] _tos, uint256[] _values, uint256 _txId) public returns (uint256 _bulkCount) {
+        require(_tos.length == _values.length, "Amount of recipients and values don't match");
+        require(_tos.length < BULK_MAX_COUNT, "Too many recipients");
+
+        uint256 _bulkValue = 0;
+        for (uint j = 0; j < _tos.length; ++j) {
+            _bulkValue = _bulkValue.add(_values[j]);
+        }
+        require(_bulkValue < BULK_MAX_VALUE, "Bulk value too high");
+
+        _bulkCount = 0;
+        bool _success;
+        for (uint i = 0; i < _tos.length; ++i) {
+            _success = transferQuiet(_tos[i], _values[i]);
+            if (_success) {
+                _bulkCount = _bulkCount.add(1);
+            }
+        }
+        emit BulkTransfer(_txId, _bulkCount);
+        return _bulkCount;
+    }
+
+    function approveBulk(address[] _spenders, uint256[] _values, uint256 _txId) public returns (uint256 _bulkCount) {
+        require(_spenders.length == _values.length, "Amount of spenders and values don't match");
+        require(_spenders.length < BULK_MAX_COUNT, "Too many spenders");
+
+        uint256 _bulkValue = 0;
+        for (uint j = 0; j < _spenders.length; ++j) {
+            _bulkValue = _bulkValue.add(_values[j]);
+        }
+        require(_bulkValue < BULK_MAX_VALUE, "Bulk value too high");
+
+        _bulkCount = 0;
+        bool _success;
+        for (uint i = 0; i < _spenders.length; ++i) {
+            _success = increaseApproval(_spenders[i], _values[i]);
+            if (_success) {
+                _bulkCount = _bulkCount.add(1);
+            }
+        }
+        emit BulkApproval(_txId, _bulkCount);
+        return _bulkCount;
+    }
+
+    // Like transfer, but fails quietly.
+    function transferQuiet(address _to, uint256 _value) internal returns (bool success) {
+        if (_to == address(0)) return false; // Preclude burning tokens to uninitialized address.
+        if (_to == address(this)) return false; // Preclude sending tokens to the contract.
+        if (balances[msg.sender] < _value) return false;
+
+        balances[msg.sender] = balances[msg.sender].sub(_value);
+        balances[_to] = balances[_to].add(_value);
+
+        emit Transfer(msg.sender, _to, _value);
+        return true;
+    }
 }
 
 
@@ -187,12 +337,12 @@ contract Escrow {
     }
 
     function getBalance() public view returns (uint256) {
-        return EIP20Interface(eip20).balanceOf(address(this));
+        return HMTokenInterface(eip20).balanceOf(address(this));
     }
 
     function getAddressBalance(address _address) public view returns (uint256) {
         require(_address != address(0), "Token spender is an uninitialized address");
-        return EIP20Interface(eip20).balanceOf(address(_address));
+        return HMTokenInterface(eip20).balanceOf(address(_address));
     }
 
     function getReputationOracle() public view returns (address) {
@@ -334,7 +484,7 @@ contract Escrow {
     }
 
     function partialPayout(uint256 _amount, address _recipient) internal returns (bool) {
-        EIP20Interface token = EIP20Interface(eip20);
+        HMTokenInterface token = HMTokenInterface(eip20);
         uint256 reputationOracleFee = reputationOracleStake.mul(_amount).div(100);
         uint256 recordingOracleFee = recordingOracleStake.mul(_amount).div(100);
         uint256 amount = _amount.sub(reputationOracleFee).sub(recordingOracleFee);

--- a/hmt.sol
+++ b/hmt.sol
@@ -331,11 +331,7 @@ contract Escrow {
         status = EscrowStatuses.Launched;
         expiration = _expiration.add(block.timestamp); // solhint-disable-line not-rely-on-time
     }
-
-    function getOracleFee(uint256 _amount, uint256 _oracleStake) public pure returns(uint256) {
-        return _oracleStake.mul(_amount).div(100);
-    }
-
+    
     function getStatus() public view returns (EscrowStatuses) {
         return status;
     }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.2.4",
+    version="0.3.0",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/test.py
+++ b/test.py
@@ -205,6 +205,28 @@ class LocalBlockchainTest(unittest.TestCase):
         self.assertEqual(to_address_balance_after_payout,
                          to_address_balance + 900)
 
+    def test_oo_bulk(self):
+        to_address = [TO_ADDR]
+        self.assertTrue(self.contract.deploy(PUB2, PRIV1))
+        self.assertEqual(self.contract.status(), api.Status.Launched)
+        contract_address = self.contract.job_contract.address
+        self.assertTrue(self.contract.fund())
+        self.assertEqual(self.contract.status(), api.Status.Launched)
+        self.assertTrue(self.contract.launch())
+        self.assertEqual(self.contract.status(), api.Status.Pending)
+        contract2 = api.get_contract_from_address(contract_address, PRIV2)
+        self.assertNotEqual({}, contract2.get_manifest(PRIV2))
+        contract2.store_intermediate({}, PUB1, PRIV2)
+        self.assertEqual({}, contract2.get_intermediate_results(PRIV1))
+
+        self.assertEqual(self.contract.status(), api.Status.Pending)
+
+        amount_to_payout = [100]
+        contract2.bulk_payout(to_address, amount_to_payout, {}, PUB2, PRIV1)
+        self.assertEqual(self.contract.status(), api.Status.Paid)
+        self.assertTrue(contract2.complete())
+        self.assertEqual(self.contract.status(), api.Status.Complete)
+
     def test_oo(self):
         to_address = TO_ADDR
         self.assertTrue(self.contract.deploy(PUB2, PRIV1))


### PR DESCRIPTION
This PR:
- Uses our actual HMToken and HMTokenInterface from `hmt-token` repo
- Adds support for bulk payments on the contract level
- Adds support for bulk payments on the python api level

Closes #42 
Closes #41 