### PR TITLE
Add refund

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -283,7 +283,7 @@ class Contract(Manifest):
 
     def fund(self) -> bool:
         """
-        Actually transfer ethereum to the contract.
+        Actually transfer ether to the contract.
         """
         return _transfer_to_address(self.job_contract.address, self.amount)
     

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -286,6 +286,12 @@ class Contract(Manifest):
         Actually transfer ethereum to the contract.
         """
         return _transfer_to_address(self.job_contract.address, self.amount)
+    
+    def refund(self) -> bool:
+        """
+        Transfer ether back to the contract initiator.
+        """
+        return _transfer_to_address(GAS_PAYER_PRIV, self.amount)
 
     def abort(self, gas=DEFAULT_GAS) -> bool:
         """

--- a/hmt.sol
+++ b/hmt.sol
@@ -425,6 +425,21 @@ contract Escrow {
         killContract();
     }
 
+    function refund() public returns (bool) {
+        require(msg.sender == canceler, "Address calling not the canceler");
+        require(status != EscrowStatuses.Partial, "Escrow in Partial status state");
+        require(status != EscrowStatuses.Complete, "Escrow in Complete status state");
+        require(status != EscrowStatuses.Paid, "Escrow in Paid status state");
+        uint256 balance = getBalance();
+        require(balance > 0, "EIP20 contract out of funds");
+
+        HMTokenInterface token = HMTokenInterface(eip20);
+        bool success = token.transfer(canceler, balance);
+        status = EscrowStatuses.Cancelled;
+        
+        return success;
+    }
+
     function complete() public returns (bool success) {
         require(expiration > block.timestamp, "Contract expired");  // solhint-disable-line not-rely-on-time
         require(msg.sender == reputationOracle, "Address calling not the reputation oracle");

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.3.3",
+    version="0.3.4",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/test.py
+++ b/test.py
@@ -279,6 +279,24 @@ class LocalBlockchainTest(unittest.TestCase):
         self.assertTrue(contract2.complete())
         self.assertEqual(self.contract.status(), api.Status.Complete)
 
+    def test_refund(self):
+        to_address = TO_ADDR
+        self.assertTrue(self.contract.deploy(PUB2, PRIV1))
+        self.assertEqual(self.contract.status(), api.Status.Launched)
+        contract_address = self.contract.job_contract.address
+        self.assertTrue(self.contract.fund())
+        self.assertEqual(self.contract.status(), api.Status.Launched)
+        self.assertTrue(self.contract.launch())
+        self.assertEqual(self.contract.status(), api.Status.Pending)
+        contract2 = api.get_contract_from_address(contract_address, PRIV2)
+        self.assertNotEqual({}, contract2.get_manifest(PRIV2))
+        contract2.store_intermediate({}, PUB1, PRIV2)
+        self.assertEqual({}, contract2.get_intermediate_results(PRIV1))
+
+        self.assertEqual(self.contract.status(), api.Status.Pending)
+        contract2.refund()
+        self.assertEqual(self.contract.status(), api.Status.Cancelled)
+
     def test_hmt_amount_convertion(self):
         per_job_cost = Decimal(self.manifest['task_bid_price'])
         hmt_amount = api._convert_to_hmt_cents(per_job_cost)


### PR DESCRIPTION
Adds refund functionality to the contract level that returns the funds to the contract initiator but doesn't kill the contract. Adds a simple test to test that contract status is updated correctly.

Closes #51 