### PR TITLE
add get_pk_from_address to eth_bridge

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -5,7 +5,7 @@ docker-compose kill || true
 yes | docker-compose rm || true
 docker-compose build
 docker-compose run -e CI=true job './bin/lint'
-docker-compose run -w /work job './bin/wait_then_run'
+docker-compose run -w /work job bash -c "./bin/wait_then_run $*"
 docker-compose run -w /work contracts
 docker-compose stop || true
 docker-compose kill || true

--- a/bin/wait_then_run
+++ b/bin/wait_then_run
@@ -2,15 +2,15 @@
 set -exu
 
 KVSTORE_ADDRESS_FILE=/deployed-kvstore/ethkvstore.address.json
-HMTTOKEN_ADDRESS_FILE=/deployed-hmttoken/hmt.address.json
+HMTOKEN_ADDR_FILE=/deployed-hmtoken/hmt.address.json
 
 
-until test -f $HMTTOKEN_ADDRESS_FILE; do
-  echo "waiting for hmt token file at $HMTTOKEN_ADDRESS_FILE .."
+until test -f $HMTOKEN_ADDR_FILE; do
+  echo "waiting for hmt token file at $HMTOKEN_ADDR_FILE .."
   sleep 2
 done
 
-export HMTOKEN_ADDR=$(cat $HMTTOKEN_ADDRESS_FILE | jq --raw-output '.address')
+export HMTOKEN_ADDR=$(cat $HMTOKEN_ADDR_FILE | jq --raw-output '.address')
 
 until test -f $KVSTORE_ADDRESS_FILE; do
   echo "waiting for $KVSTORE_ADDRESS_FILE .."

--- a/bin/wait_then_run
+++ b/bin/wait_then_run
@@ -1,12 +1,9 @@
 #!/bin/bash
 set -exu
-DONE=false
-JOB=${1-'python3 hmt_escrow/job.py -v'}
-STORAGE=${1-'python3 hmt_escrow/storage.py -v'}
-ETH_BRIDGE=${1-'python3 hmt_escrow/eth_bridge.py -v'}
 
 KVSTORE_ADDRESS_FILE=/deployed-kvstore/ethkvstore.address.json
 HMTTOKEN_ADDRESS_FILE=/deployed-hmttoken/hmt.address.json
+
 
 until test -f $HMTTOKEN_ADDRESS_FILE; do
   echo "waiting for hmt token file at $HMTTOKEN_ADDRESS_FILE .."
@@ -27,6 +24,12 @@ until curl --silent ipfs:5001; do
   sleep 1
 done
 
-$JOB
-$STORAGE
-$ETH_BRIDGE
+
+export PYTHONPATH=$(pwd)
+if [ ! -z $* ]; then
+  $*
+else
+  python3 hmt_escrow/job.py -v
+  python3 hmt_escrow/storage.py -v
+  python3 hmt_escrow/eth_bridge.py
+fi

--- a/bin/wait_then_run
+++ b/bin/wait_then_run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -exu
 
-KVSTORE_ADDRESS_FILE=/deployed-kvstore/ethkvstore.address.json
+KVSTORE_ADDR_FILE=/deployed-kvstore/ethkvstore.address.json
 HMTOKEN_ADDR_FILE=/deployed-hmtoken/hmt.address.json
 
 
@@ -12,12 +12,12 @@ done
 
 export HMTOKEN_ADDR=$(cat $HMTOKEN_ADDR_FILE | jq --raw-output '.address')
 
-until test -f $KVSTORE_ADDRESS_FILE; do
-  echo "waiting for $KVSTORE_ADDRESS_FILE .."
+until test -f $KVSTORE_ADDR_FILE; do
+  echo "waiting for $KVSTORE_ADDR_FILE .."
   sleep 2
 done
 
-export KVSTORE_CONTRACT=$(cat $KVSTORE_ADDRESS_FILE | jq --raw-output '.address')
+export KVSTORE_CONTRACT=$(cat $KVSTORE_ADDR_FILE | jq --raw-output '.address')
 
 until curl --silent ipfs:5001; do
   echo "sleeping"

--- a/bin/wait_then_run
+++ b/bin/wait_then_run
@@ -5,14 +5,24 @@ JOB=${1-'python3 hmt_escrow/job.py -v'}
 STORAGE=${1-'python3 hmt_escrow/storage.py -v'}
 ETH_BRIDGE=${1-'python3 hmt_escrow/eth_bridge.py -v'}
 
-until test -f /deployed/hmt.address.json; do
-  echo "waiting for hmt.address.json .."
+KVSTORE_ADDRESS_FILE=/deployed-kvstore/ethkvstore.address.json
+HMTTOKEN_ADDRESS_FILE=/deployed-hmttoken/hmt.address.json
+
+until test -f $HMTTOKEN_ADDRESS_FILE; do
+  echo "waiting for hmt token file at $HMTTOKEN_ADDRESS_FILE .."
   sleep 2
 done
 
-export HMTOKEN_ADDR=$(cat /deployed/hmt.address.json | jq --raw-output '.address')
+export HMTOKEN_ADDR=$(cat $HMTTOKEN_ADDRESS_FILE | jq --raw-output '.address')
 
-until curl --silent ipfs:5001; do 
+until test -f $KVSTORE_ADDRESS_FILE; do
+  echo "waiting for $KVSTORE_ADDRESS_FILE .."
+  sleep 2
+done
+
+export KVSTORE_CONTRACT=$(cat $KVSTORE_ADDRESS_FILE | jq --raw-output '.address')
+
+until curl --silent ipfs:5001; do
   echo "sleeping"
   sleep 1
 done

--- a/bin/wait_then_run
+++ b/bin/wait_then_run
@@ -29,7 +29,7 @@ export PYTHONPATH=$(pwd)
 if [ ! -z $* ]; then
   $*
 else
-  python3 hmt_escrow/job.py -v
-  python3 hmt_escrow/storage.py -v
+  python3 hmt_escrow/job.py
+  python3 hmt_escrow/storage.py
   python3 hmt_escrow/eth_bridge.py
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - ganache
       - ipfs
       - hmt
+      - kvstore
     volumes:
       - hmt_token_address:/deployed-hmttoken
       - eth_kvstore_address:/deployed-kvstore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       - hmt
       - kvstore
     volumes:
-      - hmt_token_address:/deployed-hmtoken
-      - eth_kvstore_address:/deployed-kvstore
+      - hmt_token_addr:/deployed-hmtoken
+      - eth_kvstore_addr:/deployed-kvstore
       - .:/work
 
   contracts:
@@ -47,7 +47,7 @@ services:
       - ETH_PORT=8545
     command: sh -c "rm /deployed/hmt.address.json; curl --retry 10 --retry-connrefused --retry-max-time 10 http://ganache:8545 && npm run compile && python -m SimpleHTTPServer"
     volumes:
-      - hmt_token_address:/deployed
+      - hmt_token_addr:/deployed
 
   kvstore:
     image: hcaptcha/eth-kvstore
@@ -58,7 +58,7 @@ services:
       - ETH_PORT=8545
       - ADDRESS_OUTPUT_FILENAME=/deployed/ethkvstore.address.json
     volumes:
-      - eth_kvstore_address:/deployed
+      - eth_kvstore_addr:/deployed
 
   ipfs:
     image: ipfs/go-ipfs
@@ -66,5 +66,5 @@ services:
       - 5001:5001
 
 volumes:
-  hmt_token_address:
-  eth_kvstore_address:
+  hmt_token_addr:
+  eth_kvstore_addr:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - hmt
       - kvstore
     volumes:
-      - hmt_token_address:/deployed-hmttoken
+      - hmt_token_address:/deployed-hmtoken
       - eth_kvstore_address:/deployed-kvstore
       - .:/work
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,15 @@ services:
     command: /work/bin/wait_then_run
     build: .
     image: hmtcentral.azurecr.io/contracts:latest
-    links: 
+    links:
       - ganache
       - ipfs
       - hmt
     volumes:
-      - hmt_token_address:/deployed
-  
+      - hmt_token_address:/deployed-hmttoken
+      - eth_kvstore_address:/deployed-kvstore
+      - .:/work
+
   contracts:
     environment:
       - ETH_HOST=ganache
@@ -33,7 +35,7 @@ services:
     command: node ./build/cli.node.js --noVMErrorsOnRPCResponse -m goat --hostname 0.0.0.0 --unlock 0x1413862c2b7054cdbfdc181b83962cb0fc11fd92 -g 1000
     ports:
       - 8545:8545
-  
+
   hmt:
     image: hcaptcha/hmt-token
     links:
@@ -45,6 +47,17 @@ services:
     volumes:
       - hmt_token_address:/deployed
 
+  kvstore:
+    image: hcaptcha/eth-kvstore
+    links:
+      - ganache
+    environment:
+      - ETH_HOST=ganache
+      - ETH_PORT=8545
+      - ADDRESS_OUTPUT_FILENAME=/deployed/ethkvstore.address.json
+    volumes:
+      - eth_kvstore_address:/deployed
+
   ipfs:
     image: ipfs/go-ipfs
     ports:
@@ -52,3 +65,4 @@ services:
 
 volumes:
   hmt_token_address:
+  eth_kvstore_address:

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -238,7 +238,7 @@ def deploy_factory(gas: int = GAS_LIMIT, **credentials) -> str:
     return contract_addr
 
 
-def get_pk_from_address(wallet_addr: str) -> bytes:
+def get_pub_key_from_addr(wallet_addr: str) -> bytes:
     """
     Given a wallet address, uses the kvstore to pull down the public key for a user
     in the hmt universe.  Requires that the `GAS_PAYER` environment variable be set to the
@@ -252,20 +252,20 @@ def get_pk_from_address(wallet_addr: str) -> bytes:
 
     >>> import os
     >>> from web3 import Web3
-    >>> get_pk_from_address('badaddress')
+    >>> get_pub_key_from_addr('badaddress')
     Traceback (most recent call last):
       File "/usr/lib/python3.6/doctest.py", line 1330, in __run
         compileflags, 1), test.globs)
-      File "<doctest __main__.get_pk_from_address[2]>", line 1, in <module>
-        get_pk_from_address('blah')
-      File "hmt_escrow/eth_bridge.py", line 268, in get_pk_from_address
+      File "<doctest __main__.get_pub_key_from_addr[2]>", line 1, in <module>
+        get_pub_key_from_addr('blah')
+      File "hmt_escrow/eth_bridge.py", line 268, in get_pub_key_from_addr
         raise ValueError('environment variable GAS_PAYER required')
     ValueError: environment variable GAS_PAYER required
     >>> os.environ['GAS_PAYER'] = "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92"
     >>> os.environ['GAS_PAYER_PRIV'] = "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
     >>> set_pub_key_at_address('blah')  #doctest: +ELLIPSIS
     AttributeDict({'transactionHash': ...})
-    >>> get_pk_from_address(os.environ['GAS_PAYER'])
+    >>> get_pub_key_from_addr(os.environ['GAS_PAYER'])
     b'blah'
     """
     # TODO: Should we try to get the checksum address here instead of assuming user will do that?
@@ -277,12 +277,12 @@ def get_pk_from_address(wallet_addr: str) -> bytes:
     w3 = get_w3()
 
     kvstore = w3.eth.contract(address=KVSTORE_CONTRACT, abi=kvstore_abi)
-    address_pk = kvstore.functions.get(GAS_PAYER, wallet_addr).call({
+    addr_pub_key = kvstore.functions.get(GAS_PAYER, wallet_addr).call({
         'from':
         GAS_PAYER
     })
-    bytes_address = bytes(address_pk, encoding='utf-8')
-    return bytes_address
+
+    return bytes(addr_pub_key, encoding='utf-8')
 
 
 def set_pub_key_at_address(pub_key: str) -> Dict[str, Any]:

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -266,10 +266,11 @@ def get_pub_key_from_addr(wallet_addr: str) -> bytes:
     ValueError: environment variable GAS_PAYER required
     >>> os.environ['GAS_PAYER'] = "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92"
     >>> os.environ['GAS_PAYER_PRIV'] = "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
-    >>> set_pub_key_at_addr('blah')  #doctest: +ELLIPSIS
+    >>> pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
+    >>> set_pub_key_at_addr(pub_key)  #doctest: +ELLIPSIS
     AttributeDict({'transactionHash': ...})
     >>> get_pub_key_from_addr(os.environ['GAS_PAYER'])
-    b'blah'
+    b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
     """
     # TODO: Should we try to get the checksum address here instead of assuming user will do that?
     GAS_PAYER = os.getenv('GAS_PAYER')

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -28,7 +28,8 @@ CONTRACTS = compile_files([
 ])
 
 # See more details about the eth-kvstore here: https://github.com/hCaptcha/eth-kvstore
-KVSTORE_CONTRACT = os.getenv("KVSTORE_CONTRACT", "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44")
+KVSTORE_CONTRACT = os.getenv("KVSTORE_CONTRACT",
+                             "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44")
 
 
 def get_w3() -> Web3:
@@ -256,9 +257,12 @@ def get_pk_from_address(wallet_addr: str) -> bytes:
     w3 = get_w3()
 
     kvstore = w3.eth.contract(address=KVSTORE_CONTRACT, abi=kvstore_abi)
-    address_pk = kvstore.functions.get(GAS_PAYER, wallet_addr).call({'from': GAS_PAYER})
+    address_pk = kvstore.functions.get(GAS_PAYER, wallet_addr).call({
+        'from': GAS_PAYER
+    })
     bytes_address = bytes(address_pk, encoding='utf-8')
     return bytes_address
+
 
 if __name__ == "__main__":
     import doctest

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -6,7 +6,7 @@ from solc import compile_files
 from web3 import Web3, HTTPProvider, EthereumTesterProvider
 from web3.contract import Contract
 from web3.middleware import geth_poa_middleware
-from .kvstore_abi import abi as kvstore_abi
+from hmt_escrow.kvstore_abi import abi as kvstore_abi
 from typing import Dict, List, Tuple, Optional, Any
 
 AttributeDict = Dict[str, Any]

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -29,7 +29,7 @@ CONTRACTS = compile_files([
 
 # See more details about the eth-kvstore here: https://github.com/hCaptcha/eth-kvstore
 KVSTORE_CONTRACT = Web3.toChecksumAddress(
-    os.getenv("KVSTORE_CONTRACT", "0xBd3EB00BA4962490BF9B8880b829ADb01311aA8B")) # "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44"
+    os.getenv("KVSTORE_CONTRACT", "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44"))
 
 
 def get_w3() -> Web3:

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -32,6 +32,7 @@ KVSTORE_CONTRACT = Web3.toChecksumAddress(
     os.getenv("KVSTORE_CONTRACT",
               "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44"))
 
+
 def get_w3() -> Web3:
     """Set up the web3 provider for serving transactions to the ethereum network.
 

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -271,6 +271,7 @@ def get_pub_key_from_addr(wallet_addr: str) -> bytes:
     AttributeDict({'transactionHash': ...})
     >>> get_pub_key_from_addr(os.environ['GAS_PAYER'])
     b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
+
     """
     # TODO: Should we try to get the checksum address here instead of assuming user will do that?
     GAS_PAYER = os.getenv('GAS_PAYER')
@@ -311,6 +312,7 @@ def set_pub_key_at_addr(pub_key: str) -> Dict[str, Any]:
     >>> pub_key_to_set = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
     >>> set_pub_key_at_addr(pub_key_to_set)  #doctest: +ELLIPSIS
     AttributeDict({'transactionHash': ...})
+
     """
     GAS_PAYER = os.getenv('GAS_PAYER')
     GAS_PAYER_PRIV = os.getenv('GAS_PAYER_PRIV')

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -29,8 +29,8 @@ CONTRACTS = compile_files([
 
 # See more details about the eth-kvstore here: https://github.com/hCaptcha/eth-kvstore
 KVSTORE_CONTRACT = Web3.toChecksumAddress(
-    os.getenv("KVSTORE_CONTRACT", "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44"))
-
+    os.getenv("KVSTORE_CONTRACT",
+              "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44"))
 
 def get_w3() -> Web3:
     """Set up the web3 provider for serving transactions to the ethereum network.

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -3,7 +3,7 @@ import os
 import sys
 import logging
 
-from decimal import *
+from decimal import Decimal
 from enum import Enum
 from typing import Dict, List, Tuple, Optional
 

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -3,9 +3,6 @@ import os
 import sys
 import logging
 
-# For accessing hmt_escrow files locally.
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from decimal import *
 from enum import Enum
 from typing import Dict, List, Tuple, Optional
@@ -35,7 +32,7 @@ def status(escrow_contract: Contract, gas_payer: str,
     ... }
     >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
     >>> job = Job(credentials, manifest)
-    
+
     After deployment status is "Launched".
     >>> job.launch(rep_oracle_pub_key)
     True
@@ -46,7 +43,7 @@ def status(escrow_contract: Contract, gas_payer: str,
         escrow_contract (Contract): the escrow contract of the Job.
         gas_payer (str): an ethereum address paying for the gas costs.
         gas (int): maximum amount of gas the caller is ready to pay.
-        
+
     Returns:
         Enum: returns the status as an enumeration.
 
@@ -80,7 +77,7 @@ def manifest_url(escrow_contract: Contract,
         escrow_contract (Contract): the escrow contract of the Job.
         gas_payer (str): an ethereum address paying for the gas costs.
         gas (int): maximum amount of gas the caller is ready to pay.
-    
+
     Returns:
         str: returns the manifest url of Job's escrow contract.
 
@@ -113,7 +110,7 @@ def manifest_hash(escrow_contract: Contract,
         escrow_contract (Contract): the escrow contract of the Job.
         gas_payer (str): an ethereum address paying for the gas costs.
         gas (int): maximum amount of gas the caller is ready to pay.
-    
+
     Returns:
         str: returns the manifest hash of Job's escrow contract.
 
@@ -133,7 +130,7 @@ def intermediate_url(escrow_contract: Contract,
         escrow_contract (Contract): the escrow contract of the Job.
         gas_payer (str): an ethereum address paying for the gas costs.
         gas (int): maximum amount of gas the caller is ready to pay.
-    
+
     Returns:
         str: returns the intermediate results url of Job's escrow contract.
 
@@ -155,7 +152,7 @@ def intermediate_hash(escrow_contract: Contract,
         escrow_contract (Contract): the escrow contract of the Job.
         gas_payer (str): an ethereum address paying for the gas costs.
         gas (int): maximum amount of gas the caller is ready to pay.
-    
+
     Returns:
         str: returns the intermediate results hash of Job's escrow contract.
 
@@ -170,8 +167,8 @@ def intermediate_hash(escrow_contract: Contract,
 
 class Job:
     """A class used to represent a given Job launched on the HUMAN network.
-    A Job  can be created from a manifest or by accessing an existing escrow contract 
-    from the Ethereum network. The manifest has to follow the Manifest model 
+    A Job  can be created from a manifest or by accessing an existing escrow contract
+    from the Ethereum network. The manifest has to follow the Manifest model
     specification at https://github.com/hCaptcha/hmt-basemodels.
 
     A typical Job goes through the following stages:
@@ -196,7 +193,7 @@ class Job:
                  escrow_manifest: Manifest = None,
                  factory_addr: str = None,
                  escrow_addr: str = None):
-        """Initializes a Job instance with values from a Manifest class and 
+        """Initializes a Job instance with values from a Manifest class and
         checks that the provided credentials are valid. An optional factory
         address is used to initialize the factory of the Job. Alternatively
         a new factory is created if no factory address is provided.
@@ -221,7 +218,7 @@ class Job:
         >>> job = Job(credentials, manifest, factory_addr)
         >>> job.factory_contract.address == factory_addr
         True
-        
+
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
         >>> job.launch(rep_oracle_pub_key)
         True
@@ -261,7 +258,7 @@ class Job:
             manifest (Manifest): an instance of the Manifest class.
             credentials (Dict[str, str]): an ethereum address and its private key.
             factory_addr (str): an ethereum address of the factory.
-        
+
         Raises:
             ValueError: if the credentials are not valid.
 
@@ -295,7 +292,7 @@ class Job:
 
     def launch(self, pub_key: bytes) -> bool:
         """Launches an escrow contract to the network, uploads the manifest
-        to IPFS with the public key of the Reputation Oracle and stores 
+        to IPFS with the public key of the Reputation Oracle and stores
         the IPFS url to the escrow contract.
 
         >>> credentials = {
@@ -347,7 +344,7 @@ class Job:
         >>> job.setup()
         Traceback (most recent call last):
         AttributeError: 'Job' object has no attribute 'job_contract'
-        
+
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -355,7 +352,7 @@ class Job:
 
         Returns:
             bool: returns True if Job is in Pending state.
-        
+
         Raises:
             AttributeError: if trying to setup the job before deploying it.
 
@@ -504,7 +501,7 @@ class Job:
         False
         >>> job.status()
         <Status.Paid: 4>
-            
+
         Returns:
             bool: returns True if contract has been destroyed successfully.
 
@@ -609,11 +606,11 @@ class Job:
         >>> rep_oracle_priv_key = b"28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         >>> job.intermediate_results(rep_oracle_priv_key)
         {'results': True}
-        
+
         Args:
             results (Dict): intermediate results of the Recording Oracle.
             pub_key (bytes): public key of the Reputation Oracle.
-        
+
         Returns:
             returns True if contract's state is updated and IPFS upload succeeds.
 
@@ -661,10 +658,10 @@ class Job:
         True
         >>> job.status()
         <Status.Complete: 5>
-        
+
         Returns:
             bool: returns True if the contract has been completed.
-            
+
         """
         txn_func = self.job_contract.functions.complete
         txn_info = {
@@ -685,7 +682,7 @@ class Job:
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
         >>> job = Job(credentials, manifest)
-        
+
         After deployment status is "Launched".
         >>> job.launch(rep_oracle_pub_key)
         True
@@ -718,7 +715,7 @@ class Job:
             escrow_contract (Contract): the contract to be read.
             gas_payer (str): an ethereum address calling the contract.
             gas (int): maximum amount of gas the caller is ready to pay.
-        
+
         Returns:
             int: returns the balance of the contract in HMT.
 
@@ -820,7 +817,7 @@ class Job:
 
         Returns:
             bool: returns True if IPFS download with the private key succeeds.
-            
+
         """
         final_results_url = self.job_contract.functions.getFinalResultsUrl(
         ).call({
@@ -856,7 +853,7 @@ class Job:
 
         Args:
             manifest (Manifest): a dict representation of the Manifest model.
-        
+
         """
         serialized_manifest = dict(manifest.serialize())
         per_job_cost = Decimal(serialized_manifest['task_bid_price'])
@@ -887,7 +884,7 @@ class Job:
 
         Args:
             **credentials: an unpacked dict of an ethereum address and its private key.
-        
+
         Returns:
             bool: returns True if the calculated and the given address match.
 
@@ -924,7 +921,7 @@ class Job:
         >>> new_job = Job(credentials=credentials, factory_addr=factory_addr, escrow_addr=escrow_addr)
         >>> new_job._factory_contains_escrow(escrow_addr, factory_addr)
         True
-        
+
         Args:
             factory_addr (str): an ethereum address of the escrow factory contract.
             escrow_addr (str): an ethereum address of the escrow contract.
@@ -933,7 +930,7 @@ class Job:
 
         Returns:
             bool: returns True escrow belongs to the factory.
-            
+
         """
         factory_contract = get_factory(factory_addr)
         return factory_contract.functions.hasEscrow(escrow_addr).call({
@@ -969,7 +966,7 @@ class Job:
             credentials (Dict[str, str]): a dict of an ethereum address and its private key.
             factory_addr (Optional[str]): an ethereum address of the escrow factory contract.
             gas (int): maximum amount of gas the caller is ready to pay.
-        
+
         Returns:
             bool: returns a factory contract.
 
@@ -1014,7 +1011,7 @@ class Job:
 
         Args:
             gas (int): maximum amount of gas the caller is ready to pay.
-        
+
         Returns:
             returns True if the last bulk payout has succeeded.
 
@@ -1043,7 +1040,7 @@ class Job:
 
         Args:
             gas (int): maximum amount of gas the caller is ready to pay.
-        
+
         Returns:
             str: returns an escrow contract address.
 
@@ -1068,10 +1065,10 @@ class Job:
 
         Args:
             gas (int): maximum amount of gas the caller is ready to pay.
-        
+
         Returns:
             bool: returns True if a new job was successfully launched to the network.
-        
+
         Raises:
             TimeoutError: if wait_on_transaction times out.
 

--- a/hmt_escrow/kvstore_abi.py
+++ b/hmt_escrow/kvstore_abi.py
@@ -1,0 +1,45 @@
+abi = """
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_key",
+        "type": "string"
+      },
+      {
+        "name": "_value",
+        "type": "string"
+      }
+    ],
+    "name": "set",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "name": "_key",
+        "type": "string"
+      }
+    ],
+    "name": "get",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]
+"""


### PR DESCRIPTION
This logic should live here instead of hmt-servers or loader.

- [x] Still need doctests before merge
- [x] Needs kvstore deployed to local blockchain in order to finish the above

Note: renames `get_pk_from_address` to `get_pub_key_from_addr` and adds a corresponding SET function: `set_pub_key_at_addr`

Fixes #86 