### PR TITLE
Remove timeout decorator from polling of manifest hash and url

### DIFF
--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -695,14 +695,6 @@ class Job:
         })
         return download(final_results_url, priv_key)
 
-    def _wait_for_manifests(self):
-        self.manifest_url = None
-        self.manifest_hash = None
-
-        while not self.manifest_url or not self.manifest_hash:
-            self.manifest_hash = self._manifest_hash()
-            self.manifest_url = self._manifest_url()
-
     def _access_job(self, factory_addr: str, escrow_addr: str, **credentials):
         """Given a factory and escrow address and credentials, access an already
         launched manifest of an already deployed escrow contract.
@@ -718,7 +710,8 @@ class Job:
 
         self.factory_contract = get_factory(factory_addr)
         self.job_contract = get_escrow(escrow_addr)
-        self._wait_for_manifests()
+        self.manifest_url = self._manifest_hash()
+        self.manifest_hash = self._manifest_url()
 
         manifest_dict = self.manifest(rep_oracle_priv_key)
         escrow_manifest = Manifest(manifest_dict)

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import logging
-import timeout_decorator
 
 # For accessing hmt_escrow files locally.
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -696,7 +695,6 @@ class Job:
         })
         return download(final_results_url, priv_key)
 
-    @timeout_decorator.timeout(30)
     def _wait_for_manifests(self):
         self.manifest_url = None
         self.manifest_hash = None

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -710,8 +710,8 @@ class Job:
 
         self.factory_contract = get_factory(factory_addr)
         self.job_contract = get_escrow(escrow_addr)
-        self.manifest_url = self._manifest_hash()
-        self.manifest_hash = self._manifest_url()
+        self.manifest_url = self._manifest_url()
+        self.manifest_hash = self._manifest_hash()
 
         manifest_dict = self.manifest(rep_oracle_priv_key)
         escrow_manifest = Manifest(manifest_dict)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.5.3",
+    version="0.5.4",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",


### PR DESCRIPTION
Apparently the timeout decorator didn't work as planned in the Job initialization. This removes it from the process of polling for the `manifest_url` and `manifest_hash`. In theory we should never enter an infinite loop if we access an existing job because they would always have a manifest hash / url. 