### PR TITLE
Add public getters

### DIFF
--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -25,6 +25,105 @@ LOG = logging.getLogger("hmt_escrow.job")
 Status = Enum('Status', 'Launched Pending Partial Paid Complete Cancelled')
 
 
+def status(escrow_contract: Contract, gas_payer: str,
+           gas: int = GAS_LIMIT) -> Enum:
+    """Returns the status of the Job.
+
+    >>> credentials = {
+    ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
+    ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
+    ... }
+    >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
+    >>> job = Job(credentials, manifest)
+    
+    After deployment status is "Launched".
+    >>> job.launch(rep_oracle_pub_key)
+    True
+    >>> status(job.job_contract, job.gas_payer)
+    <Status.Launched: 1>
+
+    Args:
+        escrow_contract (Contract): the escrow contract of the Job.
+        gas_payer (str): an ethereum address paying for the gas costs.
+        gas (int): maximum amount of gas the caller is ready to pay.
+        
+    Returns:
+        Enum: returns the status as an enumeration.
+
+    """
+    status_ = escrow_contract.functions.getStatus().call({
+        'from': gas_payer,
+        'gas': gas
+    })
+    return Status(status_ + 1)
+
+
+def manifest_url(escrow_contract: Contract,
+                 gas_payer: str,
+                 gas: int = GAS_LIMIT) -> str:
+    """Retrieves the deployd manifest url uploaded on Job initialization.
+
+    >>> credentials = {
+    ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
+    ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
+    ... }
+    >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
+    >>> job = Job(credentials, manifest)
+    >>> job.launch(rep_oracle_pub_key)
+    True
+    >>> job.setup()
+    True
+    >>> manifest_hash(job.job_contract, job.gas_payer) == job.manifest_hash
+    True
+
+    Args:
+        escrow_contract (Contract): the escrow contract of the Job.
+        gas_payer (str): an ethereum address paying for the gas costs.
+        gas (int): maximum amount of gas the caller is ready to pay.
+    
+    Returns:
+        str: returns the manifest url of Job's escrow contract.
+
+    """
+    return escrow_contract.functions.getManifestUrl().call({
+        'from': gas_payer,
+        'gas': gas
+    })
+
+
+def manifest_hash(escrow_contract: Contract,
+                  gas_payer: str,
+                  gas: int = GAS_LIMIT) -> str:
+    """Retrieves the deployd manifest hash uploaded on Job initialization.
+
+    >>> credentials = {
+    ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
+    ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
+    ... }
+    >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
+    >>> job = Job(credentials, manifest)
+    >>> job.launch(rep_oracle_pub_key)
+    True
+    >>> job.setup()
+    True
+    >>> manifest_hash(job.job_contract, job.gas_payer) == job.manifest_hash
+    True
+
+    Args:
+        escrow_contract (Contract): the escrow contract of the Job.
+        gas_payer (str): an ethereum address paying for the gas costs.
+        gas (int): maximum amount of gas the caller is ready to pay.
+    
+    Returns:
+        str: returns the manifest hash of Job's escrow contract.
+
+    """
+    return escrow_contract.functions.getManifestHash().call({
+        'from': gas_payer,
+        'gas': gas
+    })
+
+
 class Job:
     """A class used to represent a given Job launched on the HUMAN network.
     A Job  can be created from a manifest or by accessing an existing escrow contract 
@@ -553,13 +652,7 @@ class Job:
             Enum: returns the status as an enumeration.
 
         """
-        status_ = self.job_contract.functions.getStatus().call({
-            'from':
-            self.gas_payer,
-            'gas':
-            gas
-        })
-        return Status(status_ + 1)
+        return status(self.job_contract, self.gas_payer)
 
     def balance(self, gas: int = GAS_LIMIT) -> int:
         """Retrieve the balance of a Job in HMT.
@@ -710,8 +803,8 @@ class Job:
 
         self.factory_contract = get_factory(factory_addr)
         self.job_contract = get_escrow(escrow_addr)
-        self.manifest_url = self._manifest_url()
-        self.manifest_hash = self._manifest_hash()
+        self.manifest_url = manifest_url(self.job_contract, gas_payer)
+        self.manifest_hash = manifest_hash(self.job_contract, gas_payer)
 
         manifest_dict = self.manifest(rep_oracle_priv_key)
         escrow_manifest = Manifest(manifest_dict)
@@ -729,66 +822,6 @@ class Job:
         number_of_answers = int(serialized_manifest['job_total_tasks'])
         self.serialized_manifest = serialized_manifest
         self.amount = Decimal(per_job_cost * number_of_answers)
-
-    def _manifest_url(self, gas: int = GAS_LIMIT) -> str:
-        """Retrieves the deployd manifest url uploaded on Job initialization.
-
-        >>> credentials = {
-        ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
-        ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
-        ... }
-        >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
-        >>> job.launch(rep_oracle_pub_key)
-        True
-        >>> job.setup()
-        True
-        >>> job._manifest_url() == job.manifest_url
-        True
-
-        Args:
-            gas (int): maximum amount of gas the caller is ready to pay.
-        
-        Returns:
-            str: returns the manifest url of Job's escrow contract.
-
-        """
-        return self.job_contract.functions.getManifestUrl().call({
-            'from':
-            self.gas_payer,
-            'gas':
-            gas
-        })
-
-    def _manifest_hash(self, gas: int = GAS_LIMIT) -> str:
-        """Retrieves the deployd manifest hash uploaded on Job initialization.
-
-        >>> credentials = {
-        ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
-        ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
-        ... }
-        >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
-        >>> job.launch(rep_oracle_pub_key)
-        True
-        >>> job.setup()
-        True
-        >>> job._manifest_hash() == job.manifest_hash
-        True
-
-        Args:
-            gas (int): maximum amount of gas the caller is ready to pay.
-        
-        Returns:
-            str: returns the manifest hash of Job's escrow contract.
-
-        """
-        return self.job_contract.functions.getManifestHash().call({
-            'from':
-            self.gas_payer,
-            'gas':
-            gas
-        })
 
     def _validate_credentials(self, **credentials) -> bool:
         """Validates whether the given ethereum private key maps to the address

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.5.4",
+    version="0.5.5",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",
@@ -16,5 +16,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "ipfsapi==0.4.3", "py-evm==0.2.0a37", "py-solc==3.2.0", "web3==4.8.3",
-        "yapf==0.25.0", "mypy==0.670"
+        "yapf==0.25.0", "mypy==0.670", "hmt-basemodels==0.1.0",
+        "timeout-decorator==0.4.1"
     ])


### PR DESCRIPTION
Adds some convenience functions for third parties that don't require the initialization of the Job class:
- `status`
- `manifest_url`
- `manifest_hash`