### PR TITLE
Add multi-cred support

### DIFF
--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -911,7 +911,8 @@ class Job:
         calculated_addr = pub_key.to_checksum_address()
         return Web3.toChecksumAddress(addr) == calculated_addr
 
-    def _validate_credentials(self, multi_credentials: List[Tuple], **credentials) -> bool:
+    def _validate_credentials(self, multi_credentials: List[Tuple],
+                              **credentials) -> bool:
         """Validates whether the given ethereum private key maps to the address
         by calculating the checksum address from the private key and comparing that
         to the given address.

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -210,6 +210,7 @@ class Job:
     """
     def __init__(self,
                  credentials: Dict[str, str],
+                 multi_credentials: Dict[str, str] = None,
                  escrow_manifest: Manifest = None,
                  factory_addr: str = None,
                  escrow_addr: str = None):
@@ -285,10 +286,10 @@ class Job:
             ValueError: if the credentials are not valid.
 
         """
-        credentials_valid = self._validate_credentials(**credentials)
+        credentials_valid = self._validate_credentials(**credentials, **multi_credentials)
         if not credentials_valid:
             raise ValueError(
-                "Given private key doesn't match the ethereum address.")
+                "Given private keys don't match the ethereum addresses.")
 
         self.gas_payer = Web3.toChecksumAddress(credentials["gas_payer"])
         self.gas_payer_priv = credentials["gas_payer_priv"]

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -1128,6 +1128,8 @@ class Job:
             }
             try:
                 handle_transaction(txn_func, *[], **txn_info)
+                self.gas_payer = gas_payer
+                self.gas_payer_priv = gas_payer_priv
                 escrow_created = True
                 break
             except:

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -914,6 +914,31 @@ class Job:
 
     def _validate_multi_credentials(
             self, multi_credentials: List[Tuple]) -> List[Tuple[Any, Any]]:
+        """Validates whether the given ethereum private key maps to the address
+        by calculating the checksum address from the private key and comparing that
+        to the given address.
+
+        >>> credentials = {
+        ...     "gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
+        ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
+        ... }
+        >>> valid_multi_credentials = [("0x1413862C2B7054CDbfdc181B83962CB0FC11fD92", "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"), ("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e")]
+        >>> job = Job(credentials, manifest, multi_credentials=valid_multi_credentials)
+        >>> job.multi_credentials
+        [('0x1413862C2B7054CDbfdc181B83962CB0FC11fD92', '28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5'), ('0x61F9F0B31eacB420553da8BCC59DC617279731Ac', '486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e')]
+
+        >>> invalid_multi_credentials = [("0x1413862C2B7054CDbfdc181B83962CB0FC11fD92", "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"), ("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5")]
+        >>> job = Job(credentials, manifest, multi_credentials=invalid_multi_credentials)
+        >>> job.multi_credentials
+        [('0x1413862C2B7054CDbfdc181B83962CB0FC11fD92', '28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5')]
+
+        Args:
+            multi_credentials (List[Tuple]): a list of tuples with ethereum address, private key pairs.
+
+        Returns:
+            List (List[Tuple]): returns a list of tuples with ethereum address, private key pairs that are valid.
+
+        """
         valid_credentials = []
         for gas_payer, gas_payer_priv in multi_credentials:
             credentials_valid = self._eth_addr_valid(gas_payer, gas_payer_priv)

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -1182,4 +1182,4 @@ class Job:
 if __name__ == "__main__":
     import doctest
     from test_manifest import manifest
-    doctest.testmod()
+    doctest.testmod(raise_on_error=True)

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -33,7 +33,7 @@ def status(escrow_contract: Contract,
     ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
     ... }
     >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-    >>> job = Job(credentials, manifest)
+    >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
     After deployment status is "Launched".
     >>> job.launch(rep_oracle_pub_key)
@@ -67,7 +67,7 @@ def manifest_url(escrow_contract: Contract,
     ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
     ... }
     >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-    >>> job = Job(credentials, manifest)
+    >>> job = Job(credentials=credentials, escrow_manifest=manifest)
     >>> job.launch(rep_oracle_pub_key)
     True
     >>> job.setup()
@@ -100,7 +100,7 @@ def manifest_hash(escrow_contract: Contract,
     ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
     ... }
     >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-    >>> job = Job(credentials, manifest)
+    >>> job = Job(credentials=credentials, escrow_manifest=manifest)
     >>> job.launch(rep_oracle_pub_key)
     True
     >>> job.setup()
@@ -211,7 +211,7 @@ class Job:
     """
     def __init__(self,
                  credentials: Dict[str, str],
-                 multi_credentials: Dict[str, str] = {},
+                 multi_credentials=[],
                  escrow_manifest: Manifest = None,
                  factory_addr: str = None,
                  escrow_addr: str = None):
@@ -225,7 +225,7 @@ class Job:
         ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.gas_payer == credentials["gas_payer"]
         True
         >>> job.gas_payer_priv == credentials["gas_payer_priv"]
@@ -237,7 +237,7 @@ class Job:
 
         Initializing a new Job instance with a factory address succeeds.
         >>> factory_addr = deploy_factory(**credentials)
-        >>> job = Job(credentials, manifest, factory_addr)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest, factory_addr=factory_addr)
         >>> job.factory_contract.address == factory_addr
         True
 
@@ -274,7 +274,7 @@ class Job:
         ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
         ... 	"gas_payer_priv": "486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e"
         ... }
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         Traceback (most recent call last):
         ValueError: Given private key doesn't match the ethereum address.
 
@@ -287,8 +287,7 @@ class Job:
             ValueError: if the credentials are not valid.
 
         """
-        credentials_valid = self._validate_credentials(credentials,
-                                                       multi_credentials)
+        credentials_valid = self._validate_credentials(*multi_credentials, **credentials)
         if not credentials_valid:
             raise ValueError(
                 "Given private keys don't match the ethereum addresses.")
@@ -326,7 +325,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
         Deploying a new Job to the ethereum network succeeds.
         >>> job.launch(rep_oracle_pub_key)
@@ -364,7 +363,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
         A Job can't be setup without deploying it first.
         >>> job.setup()
@@ -433,7 +432,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -498,7 +497,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
         The escrow contract is in Pending state after setup so it can be aborted.
         >>> job.launch(rep_oracle_pub_key)
@@ -509,7 +508,7 @@ class Job:
         True
 
         The escrow contract is in Partial state after the first payout and it can't be aborted.
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -557,7 +556,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
         The escrow contract is in Pending state after setup so it can be cancelled.
         >>> job.launch(rep_oracle_pub_key)
@@ -574,7 +573,7 @@ class Job:
         <Status.Cancelled: 6>
 
         The escrow contract is in Partial state after the first payout and it can't be cancelled.
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -620,7 +619,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -662,7 +661,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -708,7 +707,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
         After deployment status is "Launched".
         >>> job.launch(rep_oracle_pub_key)
@@ -730,7 +729,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -760,7 +759,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -790,7 +789,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -824,7 +823,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -893,8 +892,8 @@ class Job:
         calculated_addr = pub_key.to_checksum_address()
         return Web3.toChecksumAddress(addr) == calculated_addr
 
-    def _validate_credentials(self, primary_credentials,
-                              multi_credentials) -> bool:
+    def _validate_credentials(self, *multi_credentials,
+                              **credentials) -> bool:
         """Validates whether the given ethereum private key maps to the address
         by calculating the checksum address from the private key and comparing that
         to the given address.
@@ -904,14 +903,14 @@ class Job:
         ...     "gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
         Validating falsy credentials fails.
         >>> credentials = {
         ...     "gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
         ... 	"gas_payer_priv": "486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e"
         ... }
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         Traceback (most recent call last):
         ValueError: Given private key doesn't match the ethereum address.
 
@@ -923,15 +922,15 @@ class Job:
 
         """
         addr_valid = False
-        gas_payer_addr = primary_credentials["gas_payer"]
-        gas_payer_priv = primary_credentials["gas_payer_priv"]
+        gas_payer_addr = credentials["gas_payer"]
+        gas_payer_priv = credentials["gas_payer_priv"]
 
         addr_valid = self._eth_addr_valid(gas_payer_addr, gas_payer_priv)
 
         if not multi_credentials:
             return addr_valid
 
-        for eth_addr, priv_key in multi_credentials.items():
+        for eth_addr, priv_key in multi_credentials:
             addr_valid = self._eth_addr_valid(eth_addr, priv_key)
             if not addr_valid:
                 LOG.error(
@@ -953,7 +952,7 @@ class Job:
         ...     "rep_oracle_priv_key": b"28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -996,13 +995,13 @@ class Job:
         ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> type(job.factory_contract)
         <class 'web3.utils.datatypes.Contract'>
 
         Initializing a new Job instance with a factory address succeeds.
         >>> factory_addr = deploy_factory(**credentials)
-        >>> job = Job(credentials, manifest, factory_addr)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest, factory_addr=factory_addr))
         >>> job.factory_contract.address == factory_addr
         True
 
@@ -1036,7 +1035,7 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
@@ -1074,7 +1073,7 @@ class Job:
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
         >>> factory_addr = deploy_factory(**credentials)
-        >>> job = Job(credentials, manifest, factory_addr)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest, factory_addr=factory_addr))
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job._last_escrow_addr() == job.job_contract.address
@@ -1101,7 +1100,7 @@ class Job:
         ... 	"gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
-        >>> job = Job(credentials, manifest)
+        >>> job = Job(credentials=credentials, escrow_manifest=manifest)
         >>> job._create_escrow()
         True
 
@@ -1119,7 +1118,7 @@ class Job:
         gas_payer = self.gas_payer
         gas_payer_priv = self.gas_payer_priv
 
-        for i in range(len(list(self.multi_credentials.keys()))):
+        for i in range(len(self.multi_credentials)):
             txn_func = self.factory_contract.functions.createEscrow
             txn_info = {
                 "gas_payer": gas_payer,
@@ -1141,10 +1140,10 @@ class Job:
         return escrow_created
 
     def _raffle_new_credentials(self):
-        return random.choice(list(self.multi_credentials.keys()))
+        return random.choice(self.multi_credentials)
 
 
 if __name__ == "__main__":
     import doctest
     from test_manifest import manifest
-    doctest.testmod(raise_on_error=True)
+    doctest.testmod()

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -213,7 +213,7 @@ class Job:
                  escrow_manifest: Manifest = None,
                  factory_addr: str = None,
                  escrow_addr: str = None,
-                 multi_credentials: list = []):
+                 multi_credentials: List[Tuple] = []):
         """Initializes a Job instance with values from a Manifest class and
         checks that the provided credentials are valid. An optional factory
         address is used to initialize the factory of the Job. Alternatively
@@ -281,6 +281,8 @@ class Job:
             manifest (Manifest): an instance of the Manifest class.
             credentials (Dict[str, str]): an ethereum address and its private key.
             factory_addr (str): an ethereum address of the factory.
+            escrow_addr (str): an ethereum address of an existing escrow address.
+            multi_credentials (List[Tuple]): a list of tuples with ethereum address, private key pairs.
 
         Raises:
             ValueError: if the credentials are not valid.
@@ -909,7 +911,7 @@ class Job:
         calculated_addr = pub_key.to_checksum_address()
         return Web3.toChecksumAddress(addr) == calculated_addr
 
-    def _validate_credentials(self, multi_credentials, **credentials) -> bool:
+    def _validate_credentials(self, multi_credentials: List[Tuple], **credentials) -> bool:
         """Validates whether the given ethereum private key maps to the address
         by calculating the checksum address from the private key and comparing that
         to the given address.
@@ -934,6 +936,7 @@ class Job:
         ValueError: Given private key doesn't match the ethereum address.
 
         Args:
+            multi_credentials (List[Tuple]): a list of tuples with ethereum address, private key pairs.
             **credentials: an unpacked dict of an ethereum address and its private key.
 
         Returns:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.1",
+    version="0.7.2",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",


### PR DESCRIPTION
Closes #155 
Added initial version of the multi-cred support. Existing API doesn't break, adds only an enhancement with `multi_credentials`.

Design decisions:
1. Use a list of tuples for easy looping when raffling new credentials
2. Just walk the list instead of taking a random when raffling new credentials. Gave it some thought and this felt a lot simpler and more deterministic. Am I missing something?
3. Added new tests to test out that raffling indeed works and launches the contract as intended to the blockchain