### PR TITLE
Add trusted handlers

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -157,10 +157,6 @@ contract Escrow {
     function abort() public {
         require(isTrustedHandler(msg.sender), "Address calling not trusted");
         require(
-            status != EscrowStatuses.Partial,
-            "Escrow in Partial status state"
-        );
-        require(
             status != EscrowStatuses.Complete,
             "Escrow in Complete status state"
         );

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -38,6 +38,7 @@ contract Escrow {
         status = EscrowStatuses.Launched;
         expiration = _expiration.add(block.timestamp); // solhint-disable-line not-rely-on-time
         launcher = msg.sender;
+        canceler = _canceler;
         trustedHandlers[_canceler] = true;
     }
 
@@ -161,7 +162,7 @@ contract Escrow {
             "Escrow in Complete status state"
         );
         require(status != EscrowStatuses.Paid, "Escrow in Paid status state");
-        selfdestruct(launcher);
+        selfdestruct(canceler);
     }
 
     function cancel() public returns (bool) {
@@ -175,7 +176,7 @@ contract Escrow {
         require(balance > 0, "EIP20 contract out of funds");
 
         HMTokenInterface token = HMTokenInterface(eip20);
-        bool success = token.transfer(launcher, balance);
+        bool success = token.transfer(canceler, balance);
         status = EscrowStatuses.Cancelled;
 
         return success;

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -11,6 +11,7 @@ contract Escrow {
     address private reputationOracle;
     address private recordingOracle;
     address private launcher;
+    address private canceler;
 
     uint256 private reputationOracleStake;
     uint256 private recordingOracleStake;

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -601,6 +601,26 @@ class Job:
         >>> job.status()
         <Status.Paid: 4>
 
+
+        Trusted handler should be able to abort an existing contract
+        >>> trusted_handler = "0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809"
+        >>> job = Job(credentials, manifest)
+        >>> job.launch(rep_oracle_pub_key)
+        True
+        >>> job.setup()
+        True
+        >>> job.add_trusted_handlers([trusted_handler])
+        True
+
+        >>> handler_credentials = {
+        ... 	"gas_payer": "0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809",
+        ... 	"gas_payer_priv": "f22d4fc42da79aa5ba839998a0a9f2c2c45f5e55ee7f1504e464d2c71ca199e1",
+        ...     "rep_oracle_priv_key": b"28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
+        ... }
+        >>> access_job = Job(credentials=handler_credentials, factory_addr=job.factory_contract.address, escrow_addr=job.job_contract.address)
+        >>> access_job.abort()
+        True
+
         Returns:
             bool: returns True if contract has been destroyed successfully.
 

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -1283,4 +1283,4 @@ class Job:
 if __name__ == "__main__":
     import doctest
     from test_manifest import manifest
-    doctest.testmod()
+    doctest.testmod(raise_on_error=True)

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -572,17 +572,9 @@ class Job:
         ... 	"gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"
         ... }
         >>> rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
-        >>> job = Job(credentials, manifest)
+        
 
-        The escrow contract is in Pending state after setup so it can be aborted.
-        >>> job.launch(rep_oracle_pub_key)
-        True
-        >>> job.setup()
-        True
-        >>> job.abort()
-        True
-
-        The escrow contract is in Partial state after the first payout and it can't be aborted.
+        The escrow contract is in Partial state after a partial bulk payout so it can be aborted.
         >>> job = Job(credentials, manifest)
         >>> job.launch(rep_oracle_pub_key)
         True
@@ -592,12 +584,16 @@ class Job:
         >>> job.bulk_payout(payouts, {}, rep_oracle_pub_key)
         True
         >>> job.abort()
-        False
-        >>> job.status()
-        <Status.Partial: 3>
+        True
 
-        The escrow contract is in Paid state after the second payout and it can't be aborted.
-        >>> payouts = [("0x852023fbb19050B8291a335E5A83Ac9701E7B4E6", Decimal('80.0'))]
+
+        The escrow contract is in Paid state after the a full bulk payout and it can't be aborted.
+        >>> job = Job(credentials, manifest)
+        >>> job.launch(rep_oracle_pub_key)
+        True
+        >>> job.setup()
+        True
+        >>> payouts = [("0x852023fbb19050B8291a335E5A83Ac9701E7B4E6", Decimal('100.0'))]
         >>> job.bulk_payout(payouts, {'results': 0}, rep_oracle_pub_key)
         True
         >>> job.abort()
@@ -1267,4 +1263,4 @@ class Job:
 if __name__ == "__main__":
     import doctest
     from test_manifest import manifest
-    doctest.testmod(raise_on_error=True)
+    doctest.testmod()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.2",
+    version="0.7.3",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/test/Escrow.js
+++ b/test/Escrow.js
@@ -82,6 +82,16 @@ contract('Escrow', (accounts) => {
         assert(true);
       }
     });
+
+    it('succeeds if caller is a trusted handler', async () => {
+      try {
+        await Escrow.addTrustedHandlers([reputationOracle])
+        await Escrow.abort({ from: reputationOracle });
+        assert(true);
+      } catch (ex) {
+        assert(false);
+      }
+    })
   });
 
   describe('calling setup', () => {


### PR DESCRIPTION
Closes #149 

Lets us specify separate cancelers on launch time, so called "trusted handlers". These will be able to abort jobs on behalf of the launcher.