### PR TITLE
Use ipfshttpclient

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,13 +7,13 @@ verify_ssl = true
 
 [packages]
 web3 = "==4.8.3"
-ipfsapi = "*"
 py-solc = "*"
 yapf = "*"
 py-evm = "==0.2.0a37"
 mypy = "*"
 hmt-basemodels = "==0.0.18"
 timeout-decorator = "*"
+ipfshttpclient = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "798c7d7befb29db668c48e889ed6114b51ec690c97ad7d0194a4af93d5b2e846"
+            "sha256": "df06685eb1f003233f1d127bc478a6b0c7694ecbd124303c6f7a1a715f62e6d7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,10 +32,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.4.5.1"
         },
         "cffi": {
             "hashes": [
@@ -79,29 +79,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
-                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
-                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
-                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
-                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
-                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
-                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
-                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
-                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
-                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
-                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
-                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
-                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
-                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
-                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
-                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
-                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
-                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
-                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
-                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
-                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+                "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e",
+                "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f",
+                "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d",
+                "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf",
+                "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02",
+                "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164",
+                "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216",
+                "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1",
+                "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1",
+                "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc",
+                "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4",
+                "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552",
+                "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088",
+                "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1",
+                "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526",
+                "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748",
+                "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc",
+                "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547",
+                "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "cytoolz": {
             "hashes": [
@@ -197,19 +195,12 @@
             ],
             "version": "==2.9"
         },
-        "ipfsapi": {
-            "hashes": [
-                "sha256:4d3fbd8b130b9d7372d94cda7aadb67b9346f261fc99fb811493e8a0a4c60550",
-                "sha256:8fde5f2cab045e326dd2735220c28c8ec995ae441cf475d46178efde4869ad9d"
-            ],
-            "index": "pypi",
-            "version": "==0.4.4"
-        },
         "ipfshttpclient": {
             "hashes": [
                 "sha256:0a199a1005fe44bff9da28b5af4785b0b09ca700baac9d1e26718fe23fe89bb7",
                 "sha256:bee95c500edf669bb8a984d5588fc133fda9ec67845c5688bcbbea030a03f10f"
             ],
+            "index": "pypi",
             "version": "==0.4.12"
         },
         "lru-dict": {
@@ -426,11 +417,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2",
-                "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d",
-                "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"
+                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
+                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
+                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
             ],
-            "version": "==3.7.4.1"
+            "version": "==3.7.4.2"
         },
         "urllib3": {
             "hashes": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - eth_kvstore_addr:/deployed
 
   ipfs:
-    image: ipfs/go-ipfs:v0.4.20
+    image: ipfs/go-ipfs:v0.4.22
     command: daemon --offline
     ports:
       - 5001:5001

--- a/hmt_escrow/storage.py
+++ b/hmt_escrow/storage.py
@@ -3,13 +3,13 @@ import logging
 import codecs
 import hashlib
 import json
-import ipfsapi
+import ipfshttpclient
 import timeout_decorator
 
 from typing import Dict, Tuple
 from eth_keys import keys
 from p2p import ecies
-from ipfsapi import Client
+from ipfshttpclient import Client
 
 SHARED_MAC_DATA = os.getenv(
     "SHARED_MAC",
@@ -22,7 +22,7 @@ IPFS_PORT = int(os.getenv("IPFS_PORT", 5001))
 
 def _connect(host: str, port: int) -> Client:
     try:
-        IPFS_CLIENT = ipfsapi.connect(host, port)
+        IPFS_CLIENT = ipfshttpclient.connect(f'/dns/{host}/tcp/{port}/http')
         return IPFS_CLIENT
     except Exception as e:
         LOG.error("Connection with IPFS failed because of: {}".format(e))

--- a/hmt_escrow/storage.py
+++ b/hmt_escrow/storage.py
@@ -4,7 +4,6 @@ import codecs
 import hashlib
 import json
 import ipfshttpclient
-import timeout_decorator
 
 from typing import Dict, Tuple
 from eth_keys import keys

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.8.0",
+    version="0.7.6",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",
@@ -16,5 +16,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "ipfshttpclient==0.4.12", "py-evm==0.2.0a37", "py-solc==3.2.0",
-        "web3==4.8.3", "timeout-decorator==0.4.1", "hmt-basemodels"
+        "web3==4.8.3", "hmt-basemodels"
     ])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.5",
+    version="0.8.0",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     install_requires=[
-        "ipfsapi==0.4.3", "py-evm==0.2.0a37", "py-solc==3.2.0", "web3==4.8.3",
-        "timeout-decorator==0.4.1", "hmt-basemodels"
+        "ipfshttpclient==0.4.12", "py-evm==0.2.0a37", "py-solc==3.2.0",
+        "web3==4.8.3", "timeout-decorator==0.4.1", "hmt-basemodels"
     ])


### PR DESCRIPTION
This is a drop in replacement that contains a ipfs http timeout feature thats more reliable than the timeout decorator, going to get rid of it in jobrunner too