### PR TITLE
Support https for Infura ipfs connection

### DIFF
--- a/hmt_escrow/storage.py
+++ b/hmt_escrow/storage.py
@@ -17,11 +17,15 @@ SHARED_MAC_DATA = os.getenv(
 LOG = logging.getLogger("hmt_escrow.storage")
 IPFS_HOST = os.getenv("IPFS_HOST", "localhost")
 IPFS_PORT = int(os.getenv("IPFS_PORT", 5001))
+IPFS_HTTPS = int(os.getenv("IPFS_HTTPS", True))
 
 
 def _connect(host: str, port: int) -> Client:
     try:
-        IPFS_CLIENT = ipfshttpclient.connect(f'/dns/{host}/tcp/{port}/http')
+        IPFS_CLIENT = ipfshttpclient.connect(
+            f'/dns/{host}/tcp/{port}/https'
+        ) if IPFS_HTTPS else ipfshttpclient.connect(
+            f'/dns/{host}/tcp/{port}/http')
         return IPFS_CLIENT
     except Exception as e:
         LOG.error("Connection with IPFS failed because of: {}".format(e))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.12",
+    version="0.7.13",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",


### PR DESCRIPTION
That `https` ending needed for Infura's ipfs. To make the switch over easier we won't need to add any env variables since it defaults to `True`

Closes #177 