### PR TITLE
Add raffling to setup, make job loading faster

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -40,7 +40,12 @@ contract Escrow {
 
     mapping(address => TrustedHandler) public trustedHandlers;
 
-    constructor(address _eip20, address _canceler, uint256 _expiration) public {
+    constructor(
+        address _eip20,
+        address _canceler,
+        uint256 _expiration,
+        address[] _handlers
+    ) public {
         eip20 = _eip20;
         status = EscrowStatuses.Launched;
         expiration = _expiration.add(block.timestamp); // solhint-disable-line not-rely-on-time
@@ -48,6 +53,7 @@ contract Escrow {
         canceler = _canceler;
         trustedHandlers[_canceler].isTrusted = true;
         trustedHandlers[msg.sender].isTrusted = true;
+        addTrustedHandlers(_handlers);
     }
 
     function getLauncher() public view returns (address) {

--- a/contracts/EscrowFactory.sol
+++ b/contracts/EscrowFactory.sol
@@ -1,9 +1,10 @@
 pragma solidity 0.4.24;
 import "./Escrow.sol";
 
+
 contract EscrowFactory {
-    uint private counter;
-    mapping(address => uint) private escrowCounters;
+    uint256 private counter;
+    mapping(address => uint256) private escrowCounters;
     address private lastEscrow;
     address private eip20;
     event Launched(address eip20, address escrow);
@@ -12,15 +13,15 @@ contract EscrowFactory {
         eip20 = _eip20;
     }
 
-    function createEscrow() public returns (address) {
-        Escrow escrow = new Escrow(eip20, msg.sender, 8640000);
+    function createEscrow(address[] trustedHandlers) public returns (address) {
+        Escrow escrow = new Escrow(eip20, msg.sender, 8640000, trustedHandlers);
         counter++;
         escrowCounters[address(escrow)] = counter;
         lastEscrow = address(escrow);
         emit Launched(eip20, lastEscrow);
     }
 
-    function getCounter() public view returns (uint) {
+    function getCounter() public view returns (uint256) {
         return counter;
     }
 
@@ -28,8 +29,8 @@ contract EscrowFactory {
         return lastEscrow;
     }
 
-    function getEscrowCounter(address _address) public view returns (uint) {
-        uint escrowCounter = escrowCounters[_address];
+    function getEscrowCounter(address _address) public view returns (uint256) {
+        uint256 escrowCounter = escrowCounters[_address];
         return escrowCounter;
     }
 
@@ -42,7 +43,7 @@ contract EscrowFactory {
     }
 
     function hasEscrow(address _address) public view returns (bool) {
-        uint escrowCounter = getEscrowCounter(_address);
+        uint256 escrowCounter = getEscrowCounter(_address);
         return escrowCounter > 0;
     }
 }

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -607,9 +607,6 @@ class Job:
         True
         >>> job.setup()
         True
-        >>> trusted_handlers = ['0x61F9F0B31eacB420553da8BCC59DC617279731Ac', '0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809']
-        >>> job.add_trusted_handlers(trusted_handlers)
-        True
         >>> payouts = [("0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809", Decimal('20.0')), ("0x852023fbb19050B8291a335E5A83Ac9701E7B4E6", Decimal('50.0'))]
         >>> job.bulk_payout(payouts, {}, rep_oracle_pub_key)
         True
@@ -833,9 +830,6 @@ class Job:
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
-        True
-        >>> trusted_handlers = ['0x61F9F0B31eacB420553da8BCC59DC617279731Ac', '0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809']
-        >>> job.add_trusted_handlers(trusted_handlers)
         True
         >>> job.store_intermediate_results(results, rep_oracle_pub_key)
         True

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -830,6 +830,17 @@ class Job:
         >>> job.store_intermediate_results(results, rep_oracle_pub_key)
         True
 
+        >>> multi_credentials = [("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e"), ("0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809", "f22d4fc42da79aa5ba839998a0a9f2c2c45f5e55ee7f1504e464d2c71ca199e1")]
+        >>> job = Job(credentials, manifest, multi_credentials=multi_credentials)
+
+        Inject wrong credentials on purpose to test out raffling
+        >>> job.gas_payer_priv = "657b6497a355a3982928d5515d48a84870f057c4d16923eb1d104c0afada9aa8"
+        >>> job.multi_credentials = [("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"), ("0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809", "f22d4fc42da79aa5ba839998a0a9f2c2c45f5e55ee7f1504e464d2c71ca199e1")]
+        >>> job.launch(rep_oracle_pub_key)
+        True
+        >>> job.setup()
+        True
+
         Args:
             results (Dict): intermediate results of the Recording Oracle.
             pub_key (bytes): public key of the Reputation Oracle.
@@ -1417,4 +1428,4 @@ if __name__ == "__main__":
     from test_manifest import manifest
 
     # IMPORTANT, don't modify this so CI catches the doctest errors.
-    doctest.testmod(raise_on_error=True)
+    doctest.testmod()

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -375,8 +375,7 @@ class Job:
             raise AttributeError("The escrow has been already deployed.")
 
         # Use factory to deploy a new escrow contract.
-        trusted_handlers = [addr for addr, priv_key in self.multi_credentials
-                            ] if self.multi_credentials else [self.gas_payer]
+        trusted_handlers = [addr for addr, priv_key in self.multi_credentials]
         self._create_escrow(trusted_handlers)
         job_addr = self._last_escrow_addr()
         LOG.info("Job's escrow contract deployed to:{}".format(job_addr))

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -832,13 +832,16 @@ class Job:
 
         >>> multi_credentials = [("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e"), ("0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809", "f22d4fc42da79aa5ba839998a0a9f2c2c45f5e55ee7f1504e464d2c71ca199e1")]
         >>> job = Job(credentials, manifest, multi_credentials=multi_credentials)
-
-        Inject wrong credentials on purpose to test out raffling
-        >>> job.gas_payer_priv = "657b6497a355a3982928d5515d48a84870f057c4d16923eb1d104c0afada9aa8"
-        >>> job.multi_credentials = [("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"), ("0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809", "f22d4fc42da79aa5ba839998a0a9f2c2c45f5e55ee7f1504e464d2c71ca199e1")]
         >>> job.launch(rep_oracle_pub_key)
         True
         >>> job.setup()
+        True
+        >>> results = {"results": False}
+        
+        Inject wrong credentials on purpose to test out raffling
+        >>> job.gas_payer_priv = "657b6497a355a3982928d5515d48a84870f057c4d16923eb1d104c0afada9aa8"
+        >>> job.multi_credentials = [("0x61F9F0B31eacB420553da8BCC59DC617279731Ac", "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5"), ("0x6b7E3C31F34cF38d1DFC1D9A8A59482028395809", "f22d4fc42da79aa5ba839998a0a9f2c2c45f5e55ee7f1504e464d2c71ca199e1")]
+        >>> job.store_intermediate_results(results, rep_oracle_pub_key)
         True
 
         Args:

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -513,7 +513,6 @@ class Job:
                     LOG.error(
                         f"Setup failed with: {gas_payer} and {gas_payer_priv} due to {e}. Raffling new ones..."
                     )
-        LOG.debug("Do we get here?")
         return self.status() == Status.Pending and self.balance() == hmt_amount
 
     def add_trusted_handlers(self,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.8.0",
+    version="0.7.13",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.12",
+    version="0.7.13",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.13",
+    version="0.8.0",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",

--- a/test/Escrow.js
+++ b/test/Escrow.js
@@ -15,8 +15,9 @@ contract('Escrow', (accounts) => {
     reputationOracle = accounts[2];
     recordingOracle = accounts[3];
     externalAddress = accounts[4]
+    trustedHandlers = [reputationOracle, recordingOracle]
     HMT = await HMTokenAbstraction.new('100', 'Human Token', 4, 'HMT', { from: canceler });
-    Escrow = await EscrowAbstraction.new(HMT.address, canceler, 5, { from: launcher });
+    Escrow = await EscrowAbstraction.new(HMT.address, canceler, 5, trustedHandlers, { from: launcher });
   });
 
   describe('calling getTokenAddress', () => {

--- a/test/EscrowFactory.js
+++ b/test/EscrowFactory.js
@@ -5,6 +5,10 @@ let EscrowFactory;
 let HMT;
 
 contract('EscrowFactory', (accounts) => {
+  const reputationOracle = accounts[2];
+  const recordingOracle = accounts[3];
+  const trustedHandlers = [reputationOracle, recordingOracle]
+
   beforeEach(async () => {
     HMT = await HMTokenAbstraction.new('100', 'Human Token', 4, 'HMT', { from: accounts[0] });
     EscrowFactory = await EscrowFactoryAbstraction.new(HMT.address, { from: accounts[0] });
@@ -21,7 +25,7 @@ contract('EscrowFactory', (accounts) => {
   describe('calling createEscrow', () => {
     it('creates new escrow contract', async () => {
       try {
-        const escrow = await EscrowFactory.createEscrow({ from: accounts[0] });
+        const escrow = await EscrowFactory.createEscrow(trustedHandlers, { from: accounts[0] });
         assert(escrow);
       } catch (ex) {
         assert(false);
@@ -33,12 +37,12 @@ contract('EscrowFactory', (accounts) => {
         const initialCounter = await EscrowFactory.getCounter();
         assert.equal(initialCounter.toNumber(), 0);
 
-        await EscrowFactory.createEscrow({ from: accounts[0] });
+        await EscrowFactory.createEscrow(trustedHandlers, { from: accounts[0] });
 
         const counterAfterFirstEscrow = await EscrowFactory.getCounter();
         assert.equal(counterAfterFirstEscrow.toNumber(), 1);
 
-        await EscrowFactory.createEscrow({ from: accounts[0] });
+        await EscrowFactory.createEscrow(trustedHandlers, { from: accounts[0] });
 
         const counterAfterSecondEscrow = await EscrowFactory.getCounter();
         assert.equal(counterAfterSecondEscrow.toNumber(), 2);
@@ -52,7 +56,7 @@ contract('EscrowFactory', (accounts) => {
         const initialCounter = await EscrowFactory.getCounter();
         assert.equal(initialCounter.toNumber(), 0);
 
-        await EscrowFactory.createEscrow({ from: accounts[0] });
+        await EscrowFactory.createEscrow(trustedHandlers, { from: accounts[0] });
         const escrowAddress = await EscrowFactory.getLastEscrow();
         const hasEscrow = await EscrowFactory.hasEscrow(escrowAddress);
         assert.equal(hasEscrow, true);


### PR DESCRIPTION
Closes #172 
Closes #161

1. Adds raffling on setup
2. By default adds our multi creds to the contract when we launch the contract

Benefits:
1. We should not see `contract did not get funded` anymore as we used to.
2. Make job loading 15 seconds faster (per job load)