### PR TITLE
Add poll latency so we don't unnecessarily poll too frequently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ COPY yarn.lock /work/
 RUN yarn
 
 COPY Pipfile Pipfile.lock /work/
-RUN pip3 install pipenv
+
+# Pin to specific version that's guaranteed to work
+RUN pip3 install 'pipenv==2018.11.26'
 RUN pipenv install --system --deploy
 
 RUN python3 -m solc.install v0.4.24

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -32,7 +32,8 @@ CONTRACTS = compile_files([
 KVSTORE_CONTRACT = Web3.toChecksumAddress(
     os.getenv("KVSTORE_CONTRACT",
               "0xbcF8274FAb0cbeD0099B2cAFe862035a6217Bf44"))
-WEB3_POLL_LATENCY = os.getenv("WEB3_POLL_LATENCY", 5)
+WEB3_POLL_LATENCY = float(os.getenv("WEB3_POLL_LATENCY", 5))
+WEB3_TIMEOUT = int(os.getenv("WEB3_TIMEOUT", 240))
 
 
 def get_w3() -> Web3:
@@ -112,10 +113,8 @@ def handle_transaction(txn_func, *args, **kwargs) -> AttributeDict:
     txn_hash = w3.eth.sendRawTransaction(signed_txn.rawTransaction)
 
     try:
-        txn_receipt = wait_for_transaction_receipt(w3,
-                                                   txn_hash,
-                                                   timeout=240,
-                                                   poll_latency=5)
+        txn_receipt = wait_for_transaction_receipt(
+            w3, txn_hash, timeout=WEB3_TIMEOUT, poll_latency=WEB3_POLL_LATENCY)
     except TimeoutError as e:
         raise e
     return txn_receipt

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.7.19",
+    version="0.7.20",
     author="HUMAN Protocol",
     description=
     "A python library to launch escrow contracts to the HUMAN network.",


### PR DESCRIPTION
Closes #190 

We've been getting 
```
Error: 429 Client Error: Too Many Requests for url: https://rinkeby.infura.io
```
recently due to `waitForTransactionReceipt` polling every 0.1 seconds.

Since it takes approx 15 seconds to write to Ethereum, this PR adds the poll latency to 5 seconds.