### PR TITLE
Fix breaking when installing new dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
-recursive-include contracts
-recursive-include migrations
+recursive-include contracts *
+recursive-include migrations *


### PR DESCRIPTION
It seems the new hmt-escrow package fails to install with pipenv. This is because of two missing `*` in the MANIFEST.in file. I have locally built and successfully installed the package after these changes.

A new release should be deployed.