### PR TITLE
Remove deps with link from setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ We'd recommend you checking out the dockerfile for an explanation of what applic
 After that the following command should install the package successfully:
 
 ```
+pip install git+https://github.com/iamdefinitelyahuman/py-solc-x@master#egg=py-solc-x \
+            git+https://github.com/ethereum/trinity@master#egg=trinity \
+            git+https://github.com/sphinx-doc/sphinx@master#egg=sphinx
+
 pip install hmt-escrow
 ```
 ### Docker

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.8.6",
+    version="0.8.7",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/hCaptcha/hmt-escrow",

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,7 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages() + ["contracts", "migrations"],
     install_requires=[
-        "py-solc-x @ https://github.com/iamdefinitelyahuman/py-solc-x@master#egg=py-solc-x",
-        "trinity @ https://github.com/ethereum/trinity@master#egg=trinity",
         "hmt-basemodels",
         "boto3",
-        "sphinx @ https://github.com/sphinx-doc/sphinx@master#egg=sphinx",
     ],
 )


### PR DESCRIPTION
When installing hmt-escrow from PyPi, there seems to be lots of issues with master tagged deps in setup.py.