### PR TITLE
Add WSS support to get_w3() 

### DIFF
--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -5,7 +5,7 @@ import unittest
 
 from solcx import compile_files
 from web3 import Web3
-from web3.providers import HTTPProvider
+from web3.providers.auto import load_provider_from_uri
 from web3.providers.eth_tester import EthereumTesterProvider
 from web3.types import TxReceipt
 from eth_typing import Address, ChecksumAddress, HexAddress, HexStr
@@ -49,6 +49,15 @@ def get_w3() -> Web3:
     >>> w3 = get_w3()
     >>> type(w3)
     <class 'web3.main.Web3'>
+    >>> type(w3.provider)
+    <class 'web3.providers.rpc.HTTPProvider'>
+
+    >>> os.environ['HMT_ETH_SERVER'] = "wss://localhost:8546"
+    >>> w3 = get_w3()
+    >>> type(w3)
+    <class 'web3.main.Web3'>
+    >>> type(w3.provider)
+    <class 'web3.providers.websocket.WebsocketProvider'>
 
     Returns:
         Web3: returns the web3 provider.
@@ -57,7 +66,9 @@ def get_w3() -> Web3:
     endpoint = os.getenv("HMT_ETH_SERVER", "http://localhost:8545")
     if not endpoint:
         LOG.error("Using EthereumTesterProvider as we have no HMT_ETH_SERVER")
-    provider = HTTPProvider(endpoint) if endpoint else EthereumTesterProvider()
+
+    provider = load_provider_from_uri(endpoint) if endpoint else EthereumTesterProvider()
+    
     w3 = Web3(provider)
     w3.middleware_onion.inject(geth_poa_middleware, layer=0)
     return w3

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -8,7 +8,7 @@ from web3 import Web3
 from web3.providers.auto import load_provider_from_uri
 from web3.providers.eth_tester import EthereumTesterProvider
 from web3.types import TxReceipt
-from eth_typing import Address, ChecksumAddress, HexAddress, HexStr
+from eth_typing import Address, ChecksumAddress, HexAddress, HexStr, URI
 from web3.contract import Contract
 from web3.middleware import geth_poa_middleware
 from web3._utils.transactions import wait_for_transaction_receipt
@@ -68,8 +68,10 @@ def get_w3() -> Web3:
     if not endpoint:
         LOG.error("Using EthereumTesterProvider as we have no HMT_ETH_SERVER")
 
-    provider = load_provider_from_uri(endpoint) if endpoint else EthereumTesterProvider()
-    
+    provider = (
+        load_provider_from_uri(URI(endpoint)) if endpoint else EthereumTesterProvider()
+    )
+
     w3 = Web3(provider)
     w3.middleware_onion.inject(geth_poa_middleware, layer=0)
     return w3
@@ -160,7 +162,7 @@ def get_escrow(escrow_addr: str) -> Contract:
     >>> job = Job(credentials=credentials, escrow_manifest=manifest)
 
     Deploying a new Job to the ethereum network succeeds.
-    
+
     >>> job.launch(rep_oracle_pub_key)
     True
     >>> type(get_escrow(job.job_contract.address))

--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -52,12 +52,13 @@ def get_w3() -> Web3:
     >>> type(w3.provider)
     <class 'web3.providers.rpc.HTTPProvider'>
 
-    >>> os.environ['HMT_ETH_SERVER'] = "wss://localhost:8546"
+    >>> os.environ["HMT_ETH_SERVER"] = "wss://localhost:8546"
     >>> w3 = get_w3()
     >>> type(w3)
     <class 'web3.main.Web3'>
     >>> type(w3.provider)
     <class 'web3.providers.websocket.WebsocketProvider'>
+    >>> del os.environ["HMT_ETH_SERVER"]
 
     Returns:
         Web3: returns the web3 provider.


### PR DESCRIPTION
**Changes**
- edited `get_w3()` to support WSS endpoints set in HMT_ETH_SERVER
     - Technically, this will now support any endpoints that are supported by `web3`'s `AutoProvider`, more below

**Reasoning**
- Fixes #236 

**Motivation**
- Instead of using a parameter, we can utilize a helper function available in `web3.providers.auto` called `load_provider_from_uri` (https://github.com/ethereum/web3.py/blob/master/web3/providers/auto.py#L46-L62) which will return the proper `Provider` to be inserted into `Web3(provider)`. This also adds support for IPC if ever needed