### PR TITLE
Added Moonbeam compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   "homepage": "https://github.com/hCaptcha/hmt-escrow#readme",
   "dependencies": {
     "@openzeppelin/contracts": "3.1.0",
+    "ethereumjs-wallet": "^1.0.0",
     "truffle": "5.1.32",
-    "truffle-hdwallet-provider": "1.0.17"
+    "truffle-hdwallet-provider": "1.0.17",
+    "web3-provider-engine": "https://github.com/MetaMask/web3-provider-engine.git"
   },
   "devDependencies": {
     "dotenv": "^6.0.0",

--- a/private-provider.js
+++ b/private-provider.js
@@ -1,0 +1,94 @@
+const ProviderEngine = require('web3-provider-engine');
+const WalletSubprovider = require('web3-provider-engine/subproviders/wallet');
+const RpcSubprovider = require('web3-provider-engine/subproviders/rpc');
+const EthereumjsWallet = require('ethereumjs-wallet');
+
+function ChainIdSubProvider(chainId) {
+   this.chainId = chainId;
+}
+
+ChainIdSubProvider.prototype.setEngine = function (engine) {
+   const self = this;
+   if (self.engine) return;
+   self.engine = engine;
+};
+ChainIdSubProvider.prototype.handleRequest = function (payload, next, end) {
+   if (
+      payload.method == 'eth_sendTransaction' &&
+      payload.params.length > 0 &&
+      typeof payload.params[0].chainId == 'undefined'
+   ) {
+      payload.params[0].chainId = this.chainId;
+   }
+   next();
+};
+
+function NonceSubProvider() { }
+
+NonceSubProvider.prototype.setEngine = function (engine) {
+   const self = this;
+   if (self.engine) return;
+   self.engine = engine;
+};
+NonceSubProvider.prototype.handleRequest = function (payload, next, end) {
+   if (payload.method == 'eth_sendTransaction') {
+      this.engine.sendAsync(
+         {
+            jsonrpc: '2.0',
+            id: Math.ceil(Math.random() * 4415011859092441),
+            method: 'eth_getTransactionCount',
+            params: [payload.params[0].from, 'latest'],
+         },
+         (err, result) => {
+            const nonce =
+               typeof result.result == 'string'
+                  ? result.result == '0x'
+                     ? 0
+                     : parseInt(result.result.substring(2), 16)
+                  : 0;
+            payload.params[0].nonce = nonce || 0;
+            next();
+         }
+      );
+   } else {
+      next();
+   }
+};
+
+function PrivateKeyProvider(privateKey, providerUrl, chainId) {
+   if (!privateKey) {
+      throw new Error(
+         `Private Key missing, non-empty string expected, got "${privateKey}"`
+      );
+   }
+
+   if (!providerUrl) {
+      throw new Error(
+         `Provider URL missing, non-empty string expected, got "${providerUrl}"`
+      );
+   }
+
+   this.wallet = EthereumjsWallet.default.fromPrivateKey(
+      new Buffer(privateKey, 'hex')
+   );
+   this.address = '0x' + this.wallet.getAddress().toString('hex');
+
+   this.engine = new ProviderEngine({ useSkipCache: false });
+
+   this.engine.addProvider(new ChainIdSubProvider(chainId));
+   this.engine.addProvider(new NonceSubProvider());
+   this.engine.addProvider(new WalletSubprovider(this.wallet, {}));
+   this.engine.addProvider(new RpcSubprovider({ rpcUrl: providerUrl }));
+
+   this.engine.start();
+}
+
+PrivateKeyProvider.prototype.sendAsync = function (payload, callback) {
+   return this.engine.sendAsync.apply(this.engine, arguments);
+};
+
+PrivateKeyProvider.prototype.send = function () {
+   return this.engine.send.apply(this.engine, arguments);
+};
+
+module.exports = PrivateKeyProvider;

--- a/truffle.js
+++ b/truffle.js
@@ -1,7 +1,8 @@
 require('dotenv').config()
 
-const { INFURA_TOKEN, MNEMONIC, ETH_HOST, ETH_PORT } = process.env;
+const { INFURA_TOKEN, MNEMONIC, PRIV_KEY, ETH_HOST, ETH_PORT } = process.env;
 const HDWalletProvider = require('truffle-hdwallet-provider');
+const PrivateKeyProvider = require('./private-provider');
 
 module.exports = {
 
@@ -31,6 +32,10 @@ module.exports = {
       networkCheckTimeout: '100000',
       gas: 0x989680,
       gasPrice: 200000000000
+    },
+    moonbase: {
+      provider: () => new PrivateKeyProvider(PRIV_KEY, 'https://rpc.testnet.moonbeam.network', 1287),
+      network_id: '1287',
     },
   },
   compilers: {


### PR DESCRIPTION
This PR adds the necessary changes so that the Truffle script works for deploy the contracts into Moonbase Alpha, the Moonbeam TestNet.

Currently, we don't support the usage of `hd-wallet-provider`, as one of the dependencies that it uses has "baked-in" the chain Id of known Ethereum Networks. Thus when you point it to Moonbase Alpha, the Chain Id is not recognized and so it is not included in the tx, making the signature invalid. Consequently, the transaction is rejected. We are currently working with Truffle to solve this issue.

In the meantime, we've programed a provider (file `private-provider.js`) which uses the [web3-provider-engine](https://github.com/MetaMask/web3-provider-engine.git) and [ethereumjs-wallet](https://github.com/ethereumjs/ethereumjs-wallet) libraries. For this specific setup, you need to provide a private key instead of the Mnemonic:

```
export PRIV_KEY="enter-private-key-here"
```
You can find more information regarding Moonbeam in the following URLs:

 - Moonbeam Network: https://moonbeam.network/
 - Documentation site: https://docs.moonbeam.network/
 - Discord Channel: https://discord.gg/PfpUATX